### PR TITLE
Improve kiosk package(s) installation

### DIFF
--- a/recipes/devices/pi-kiosk.sh
+++ b/recipes/devices/pi-kiosk.sh
@@ -11,7 +11,7 @@ source "${SRC}"/recipes/devices/pi.sh
 
 # Enable kiosk
 KIOSKMODE=yes
-KIOSKBROWSER=vivaldi
+KIOSKBROWSER=chromium
 
 # We need a bigger image size
 BOOT_END=180

--- a/scripts/components/install-kiosk-chromium.sh
+++ b/scripts/components/install-kiosk-chromium.sh
@@ -9,6 +9,9 @@ log "Installing $CMP_NAME" "ext"
 source /etc/os-release
 export DEBIAN_FRONTEND=noninteractive
 
+# Some (more) raspbian specific schenanigans
+BrowerPckg="chromium"
+[[ ${ID} == raspbian ]] && BrowerPckg+="-browser"
 CMP_PACKAGES=(
   # Keyboard config
   "keyboard-configuration"
@@ -16,7 +19,7 @@ CMP_PACKAGES=(
   "openbox" "unclutter" "xorg" "xinit"
   # Browser
   # TODO: Why not firefox? it seems to work OTB on most devices with less hassle?
-  "chromium" "chromium-l10n"
+  "${BrowerPckg}" "chromium-l10n"
   # Fonts
   "fonts-arphic-ukai" "fonts-arphic-gbsn00lp" "fonts-unfonts-core"
   # Fonts for Japanese and Thai languages

--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -210,12 +210,11 @@ if [[ "${INIT_PLYMOUTH_DISABLE}" == yes ]]; then
 fi
 
 if [[ "${KIOSKMODE}" == yes ]]; then
-  if [[ "${KIOSKBROWSER}" == vivaldi ]]; then
-    log "Copying Vivaldi kiosk scripts to rootfs"
-    cp "${SRC}/scripts/components/install-kiosk-vivaldi.sh" "${ROOTFSMNT}"/install-kiosk.sh
+  if [[ -f "${SRC}/scripts/components/install-kiosk-${KIOSKBROWSER:=chromium}.sh" ]]; then
+    log "Copying scripts to rootfs" "${KIOSKBROWSER}"
+    cp "${SRC}/scripts/components/install-kiosk-${KIOSKBROWSER}.sh" "${ROOTFSMNT}"/install-kiosk.sh
   else
-    log "Copying Chromium kiosk scripts to rootfs"
-    cp "${SRC}/scripts/components/install-kiosk.sh" "${ROOTFSMNT}"/install-kiosk.sh
+    log "Kioskmode enabled, but install-kiosk-${KIOSKBROWSER} was not found!" "err"
   fi
 fi
 
@@ -246,8 +245,8 @@ UINITRD_ARCH="${UINITRD_ARCH}"
 KERNEL_VERSION="${KERNEL_VERSION}"
 DEBUG_IMAGE="${DEBUG_IMAGE:-no}"
 KIOSKMODE="${KIOSKMODE:-no}"
-KIOSKBROWSER="${KIOSKBROWSER:-chromium}"
-KIOSKINSTALL="${KIOSKMODE:-install-kiosk.sh}"
+KIOSKBROWSER="${KIOSKBROWSER}"
+KIOSKINSTALL="${KIOSKMODE:-install-kiosk-${KIOSKBROWSER}.sh}"
 VARIANT=${VARIANT}
 VOLVARIANT="${VOLVARIANT:-volumio}"
 BOOT_FS_SPEC=${BOOT_FS_SPEC}


### PR DESCRIPTION
This gets things rolling, but we need to seriously review all the chromium flags being set.

We should also consolidate with the ones set by @gvolt at [`touch_display`](https://github.com/volumio/volumio-plugins-sources/blob/master/touch_display/install.sh). 