### PR TITLE
Qrcode on welcome screen with IP listenner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ logs
 platform-*
 myVolumioSDK
 VolumioSDK*
+image_info
 
 # We don't need logs and image artifacts
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ VolumioSDK*
 *.log
 *.zip
 *.img*
-*.tar*
+# Changed - blocks service type targets
+*.tar
+*.tar.*
 # Selective ignore
 .ignore_dir
 

--- a/scripts/rootfs/configure.sh
+++ b/scripts/rootfs/configure.sh
@@ -52,6 +52,11 @@ for service in "${SRC}"/volumio/lib/systemd/system/*.service; do
   cp  "${service}" "${ROOTFS}"/lib/systemd/system/
 done
 
+for target in "${SRC}"/volumio/lib/systemd/system/*.target; do
+  log "Copying ${target}" 
+  cp  "${target}" "${ROOTFS}"/lib/systemd/system/
+done
+
 # Network
 cp -r "${SRC}"/volumio/etc/network/* "${ROOTFS}"/etc/network
 

--- a/scripts/rootfs/volumioconfig.sh
+++ b/scripts/rootfs/volumioconfig.sh
@@ -361,6 +361,9 @@ ln -s /lib/systemd/system/volumiossh.service /etc/systemd/system/multi-user.targ
 # log "Enable Volumio Log Rotation Service"
 # ln -s /lib/systemd/system/volumiologrotate.service /etc/systemd/system/multi-user.target.wants/volumiologrotate.service
 
+log "Enable Volumio IP Change Monitoring Service"
+ln -s /lib/systemd/system/volumio-ipchange.service /etc/systemd/system/multi-user.target.wants/volumio-ipchange.service
+
 log "Enable Volumio Welcome Service"
 ln -s /lib/systemd/system/welcome.service /etc/systemd/system/multi-user.target.wants/welcome.service
 

--- a/volumio/bin/welcome
+++ b/volumio/bin/welcome
@@ -2,6 +2,6 @@
 
 IFS=" " read -r -a ip_addresses < <(hostname -I)
 echo "Resolved ip:[${#ip_addresses[@]}] ${ip_addresses[*]}"
-sudo sed -i '/WebUI /q' /etc/issue
-qrencode -m 2 -8 -t utf8 <<<"http://${ip_addresses[0]}" >>/etc/issue
-sudo agetty --reload
+/usr/bin/sed -i '/WebUI /q' /etc/issue
+/usr/bin/qrencode -m 2 -8 -t utf8 <<<"http://${ip_addresses[0]}" >>/etc/issue
+agetty --reload

--- a/volumio/lib/systemd/system/ip-changed@.target
+++ b/volumio/lib/systemd/system/ip-changed@.target
@@ -1,0 +1,3 @@
+[Unit]
+# Part of volumio-ipchange monitoring service
+Description=IP Address changed on %i

--- a/volumio/lib/systemd/system/volumio-ipchange.service
+++ b/volumio/lib/systemd/system/volumio-ipchange.service
@@ -1,0 +1,11 @@
+[Unit]
+# Adopted from https://clinta.github.io/run-service-on-ip-change/ 
+Description=Volumio IP Change Monitor
+Requires=network.target
+After=network-online.target
+
+[Service]
+ExecStart=:/bin/bash -c "ip mon addr | sed -nu -r 's/.*[[:digit:]]+:[[:space:]]+([^[:space:]]+).*/\\1/p\' | while read iface; do systemctl restart ip-changed@${iface}.target; done"
+
+[Install]
+WantedBy=multi-user.target default.target

--- a/volumio/lib/systemd/system/welcome.service
+++ b/volumio/lib/systemd/system/welcome.service
@@ -7,3 +7,5 @@ Requires=network-online.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/welcome
+User=root
+Group=root

--- a/volumio/lib/systemd/system/welcome.service
+++ b/volumio/lib/systemd/system/welcome.service
@@ -2,6 +2,8 @@
 Description=Show a welcome message on console
 After=network-online.target
 Requires=network-online.target
+PartOf=ip-changed@eth0.target ip-changed@wlan0.target
+Before=ip-changed@eth0.target ip-changed@wlan0.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The welcome.service is now aware of IP address on network devices.
The additional volumio-ipchange service acts as a trigger for network interfaces whilst being restarted from static unit with descendants ip-changed@.target.
Any service depending on IP address change can be extended by making such service to be part of ip-monitor:
[Unit]
...
PartOf=ip-changed@eth0.target ip-changed@wlan0.target
Before=ip-changed@eth0.target ip-changed@wlan0.target

