### PR TITLE
Cleaning legacy sysv-rc leftovers

### DIFF
--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -274,6 +274,8 @@ chroot "${ROOTFSMNT}" /chrootconfig.sh
 log "Finished chroot config for ${DEVICE}" "okay"
 # Clean up chroot stuff
 rm "${ROOTFSMNT:?}"/*.sh "${ROOTFSMNT}"/root/init
+log "Cleaning legacy sysv-rc leftovers" "okay"
+rm "${ROOTFSMNT}"/etc/init.d/README
 
 unmount_chroot "${ROOTFSMNT}"
 end_chroot_final=$(date +%s)


### PR DESCRIPTION
Sysvinit documentation is truncated when image is being built. Aftre booting, the dmesg reports litter as:
systemd[1]: memfd_create() called without MFD_EXEC or MFD_NOEXEC_SEAL set
systemd-sysv-generator[1220]: stat() failed on /etc/init.d/README, ignoring: No such file or directory
