### PR TITLE
[x86] - Update device missing volbins

### DIFF
--- a/recipes/base/x86.conf
+++ b/recipes/base/x86.conf
@@ -8,7 +8,7 @@ debootstrap=Accessories Assets Base BaseDebPlus Bluetooth FS Firmware Kiosk Net 
 
 # Add additional x86 specific packages (if required)
 [x86]
-packages=acpid dmidecode gdisk grub-common inxi lshw pciutils syslinux syslinux-common alsa-ucm-conf
+packages=acpid dmidecode fdisk gdisk grub-common inxi lshw pciutils syslinux syslinux-common alsa-ucm-conf
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=bookworm

--- a/scripts/initramfs/mkinitramfs-custom.sh
+++ b/scripts/initramfs/mkinitramfs-custom.sh
@@ -574,7 +574,7 @@ build_volumio_initramfs() {
     '/sbin/e2fsck' '/sbin/resize2fs' '/sbin/mke2fsfull' '/sbin/mkfs.vfat')
   if [[ ${DPKG_ARCH} = 'i386' ]] || [[ ${DPKG_ARCH} = 'amd64' ]]; then
     log "Adding x86/x64 specific binaries (sgdisk/lsblk/dmidecode..etc)" "info"
-    volbins+=('/sbin/fdisk' '/sbin/sgdisk' '/usr/sbin/dmidecode')
+    volbins+=('/usr/sbin/fdisk' '/usr/sbin/sgdisk' '/usr/sbin/dmidecode')
   fi
   # mkinitramfs for installer's do not have a volumio-init-updater
   if [[ -f "/usr/local/sbin/volumio-init-updater" ]]; then


### PR DESCRIPTION
Bookworm uses unity /bin -> /usr/bin ; /sbin -> /usr/sbin folders since Debian 11. In theory should be no difference.

In init however we need to add fdisk utility at the device level.
Impact discussed here: https://github.com/volumio/volumio-os/issues/57