### PR TITLE
[init] - Bookworm: manage device partiton table

### DIFF
--- a/scripts/initramfs/README.md
+++ b/scripts/initramfs/README.md
@@ -102,7 +102,7 @@ Use ```maybe_volumio_break <break name> "init: $LINENO"``` for that and remove t
 
 ### Valid breakpoints are:
 ```
-top, modules, premount, mount, udev-slumber, cust-init-part, init-part-pars, progress, backup_gpt, krnl-archive, search-for-firmw, search-fact-reset, search-fact-reset, krnl-rollbck,krnl-upd, resize-data, mnt-overlayfs, cust-upd-uuid, updfstab, bottom, init
+top, modules, premount, mount, udev-slumber, cust-init-part, init-part-pars, progress, dev_partiton, krnl-archive, search-for-firmw, search-fact-reset, search-fact-reset, krnl-rollbck,krnl-upd, resize-data, mnt-overlayfs, cust-upd-uuid, updfstab, bottom, init
 ```
 
 ### Configuring a breakpoint

--- a/scripts/initramfs/initv3
+++ b/scripts/initramfs/initv3
@@ -406,9 +406,9 @@ mount -t ext4 "${IMAGE_PARTITION}" "${IMAGEMNT}"
 # In case of a gpt boot partition: move the backup table when not done yet
 # This function is also safe for non-gpt boot partitions (it will not trigger a mismatch).
 #
-maybe_volumio_break backup_gpt "init: $LINENO"
+maybe_volumio_break dev_partiton "init: $LINENO"
 
-move_backup_gpt_table
+maintain_device_partitions
 
 #
 #

--- a/scripts/initramfs/scripts/volumio-functions
+++ b/scripts/initramfs/scripts/volumio-functions
@@ -10,7 +10,7 @@ maybe_volumio_break() {
 # Breakpoints are specified on the kernel cmdline using the 'break=', comma-separated.
 #
 # Valid breakpoints are:
-#       top, modules, premount, mount, cust-init-part, init-part-pars, progress, backup_gpt,
+#       top, modules, premount, mount, cust-init-part, init-part-pars, progress, dev_partiton,
 #       krnl-archive, search-for-firmw, search-fact-reset, search-fact-reset, krnl-rollbck,
 #       krnl-upd, resize-data, mnt-overlayfs, cust-upd-uuid, updfstab, bottom and init
 # Globals
@@ -255,19 +255,11 @@ for i in 1 2 3 4 5
   log_end_msg
 }
 
-
-move_backup_gpt_table() {
-
-# GPT partitions: as the Volumio image likely has been dd'ed to a bigger disk,
-#     the backup GPT table is not at the end of the disk.
-# 		Fix this before doing anything else (only at first boot)
-  
-  GPTSIZEMISMATCH="$(/sbin/fdisk -l ${BOOT_DEVICE} 2>&1 | grep 'GPT PMBR size mismatch')"
-  if [ ! "x${GPTSIZEMISMATCH}" == "x" ]; then
-    log_begin_msg "Alternate (backup) GPT header not at the end of the disk, moving it..."
-    sgdisk -e "${BOOT_DEVICE}" >/dev/null 2>&1
-    log_end_msg 
-  fi
+maintain_device_partitions() {
+  # Placeholder for device specific partition fix or procedures.
+  # x86 - uses it to update gpt partitions: as the Volumio image likely has been dd'ed to a bigger disk.
+  # Pi - uses it to fix incorrectly unmount vfat boot partition. 
+  :
 }
 
 create_kernel_archive() {


### PR DESCRIPTION
replace move_backup_gpt_table with maintain_device_partition
consumer - custom-functions at the device recipe level