### PR TITLE
make firmware and platform archives optional; add support for chunked input

### DIFF
--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -153,6 +153,22 @@ fi
 if [[ "${HAS_PLTDIR}" == yes ]]; then
   # This is pulled in from each device's config script
   log "Copying ${DEVICE} boot files from platform-${DEVICEFAMILY}/${DEVICEBASE}.tar.xz" "info"
+
+  PLATFORM_ARCHIVE="${PLTDIR}/${DEVICEBASE}.tar.xz"
+  PLATFORM_CHUNKS="${PLATFORM_ARCHIVE}.part_"
+  TEMP_REASSEMBLED="${PLATFORM_ARCHIVE}.reassembled"
+
+  if ls "${PLATFORM_CHUNKS}"* 1>/dev/null 2>&1; then
+    log "Detected chunked platform archive, reassembling..." "info"
+    cat "${PLATFORM_CHUNKS}"* > "${TEMP_REASSEMBLED}"
+    tar xfJ "${TEMP_REASSEMBLED}" -C "${PLTDIR}/"
+    rm -f "${TEMP_REASSEMBLED}"
+  elif [[ -f "${PLATFORM_ARCHIVE}" ]]; then
+    tar xfJ "${PLATFORM_ARCHIVE}" -C "${PLTDIR}/"
+  else
+    log "No platform archive found for ${DEVICEBASE}, skipping platform extraction" "wrn"
+  fi
+
   log "Entering write_device_files" "cfg"
   write_device_files
   log "Entering write_device_bootloader" "cfg"


### PR DESCRIPTION
- add detection and reassembly of .tar.xz.part_* chunk sets for firmware and platform archives
- extract from reassembled .tar.xz if chunks present; fallback to full archive if available
- suppress hard failure if firmware archive is missing; log warning instead
- suppress hard failure if platform archive is missing; log warning instead
- preserves compatibility with devices that do not require firmware or platform overlays
- ensures compatibility with GitHub’s file size limits without breaking build logic