### PR TITLE
[x86] - Add support for platform repo branch selection

### DIFF
--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -16,6 +16,7 @@ DEVICEFAMILY="x64"
 # tarball from DEVICEFAMILY repo to use
 #DEVICEBASE=${DEVICE} # Defaults to ${DEVICE} if unset
 DEVICEREPO="http://github.com/volumio/platform-${DEVICEFAMILY}"
+DEVICEREPO_BRANCH="6.12.28" # Branch to use for the device repo or empty for main
 
 ### What features do we want to target
 # TODO: Not fully implemented

--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -128,15 +128,17 @@ fi
 
 log "Getting device specific files for ${DEVICE} from platform-${DEVICEFAMILY}" "info"
 PLTDIR="${SRC}/platform-${DEVICEFAMILY}"
+
 if [[ -d "${PLTDIR}" ]]; then
   log "Platform folder exists, keeping it" "" "platform-${DEVICEFAMILY}"
   HAS_PLTDIR=yes
 elif [[ -n "${DEVICEREPO}" ]]; then
-  log "Cloning platform-${DEVICEFAMILY} from ${DEVICEREPO}"
-  git clone --depth 1 "${DEVICEREPO}" "platform-${DEVICEFAMILY}"
+  DEVICEREPO_BRANCH="${DEVICEREPO_BRANCH:-main}"
+  log "Cloning platform-${DEVICEFAMILY} from ${DEVICEREPO} (branch: ${DEVICEREPO_BRANCH})" "info"
+  git clone --branch "${DEVICEREPO_BRANCH}" --depth 1 "${DEVICEREPO}" "platform-${DEVICEFAMILY}"
   HAS_PLTDIR=yes
 else
-  log "No platform-${DEVICEFAMILY} found, skipping this step"
+  log "No platform-${DEVICEFAMILY} found, skipping this step" "wrn"
   HAS_PLTDIR=no
 fi
 


### PR DESCRIPTION
- allow optional DEVICEREPO_BRANCH to override default branch
- fallback to default clone behavior if not specified
- supports use of stable or feature branches per device or kernel line