### PR TITLE
Add firmware-volumio.tar.gz for Raspberry Pi

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -237,6 +237,7 @@ device_chroot_tweaks_pre() {
 		[Bassowl]="https://raw.githubusercontent.com/Darmur/bassowl-hat/master/driver/archives/modules-rpi-${KERNEL_VERSION}-bassowl.tar.gz"
 		[wm8960]="https://raw.githubusercontent.com/hftsai256/wm8960-rpi-modules/main/wm8960-modules-rpi-${KERNEL_VERSION}.tar.gz"
 		[brcmfmac43430b0]="https://raw.githubusercontent.com/volumio/volumio3-os-static-assets/master/firmwares/brcmfmac43430b0/brcmfmac43430b0.tar.gz"
+		[vfirmware]="https://raw.githubusercontent.com/volumio/volumio3-os-static-assets/master/firmwares/bookworm/firmware-volumio.tar.gz"
 		[PiCustom]="https://raw.githubusercontent.com/Darmur/volumio-rpi-custom/main/output/modules-rpi-${KERNEL_VERSION}-custom.tar.gz"
 	)
 


### PR DESCRIPTION
This PR adds the finalized `firmware-volumio.tar.gz` firmware bundle for Volumio on Raspberry Pi.

Contents include:
- Blobs from linux-firmware.git (e.g., mediatek/, rtlwifi/, rtl_nic/)
- Manually injected Realtek and Ralink firmware:
  - rtl_bt/rtl8723cs_cg_config.bin
  - rtl_bt/rtl8723cs_cg_fw.bin
  - rtl_bt/rtl8723ds_config.bin
  - rtl_bt/rtl8723ds_fw.bin
  - rt3070.bin