### PR TITLE
Ensure rfkill unblock before hostapd startup in image build

### DIFF
--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -98,9 +98,9 @@ write_device_files() {
   mkdir -p "${ROOTFSMNT}"/usr/local/bin/
   declare -A CustomScripts=(
     [bytcr_init.sh]="bytcr-init/bytcr_init.sh"
-    [handle_jackdetect_event.sh]="acpi/handlers/handle_jackdetect_event.sh"
-    [handle_mute_event.sh]="acpi/handlers/handle_mute_button_event.sh"
-    [handle_brightness_event.sh]="acpi/handlers/handle_brightness_event.sh"
+    [handle_jack-headphone_event.sh]="acpi/handlers/handle_jack-headphone_event.sh"
+    [handle_mute-button_event.sh]="acpi/handlers/handle_mute-button_event.sh"
+    [handle_brightness-button_event.sh]="acpi/handlers/handle_brightness-button_event.sh"
     [volumio_hda_intel_tweak.sh]="hda-intel-tweaks/volumio_hda_intel_tweak.sh"
     [x86Installer.sh]="x86Installer/x86Installer.sh"
   )
@@ -139,12 +139,12 @@ EOF
   # Headphone detect currently only for atom z8350 with rt5640 codec
   # Evaluate additional requirements when they arrive
   log "Copying acpi events for headphone jack detect (z8350 with rt5640 only)" "info"
-  cp "${PLTDIR}/${DEVICE}"/utilities/acpi/events/jackdetect-event "${ROOTFSMNT}"/etc/acpi/events
+  cp "${PLTDIR}/${DEVICE}"/utilities/acpi/events/jack-headphone_event "${ROOTFSMNT}"/etc/acpi/events
   
   # Generic acpi events
   log "Copying acpi events for mute and brightness buttons" "info"
-  cp "${PLTDIR}/${DEVICE}"/utilities/acpi/events/brightness-event "${ROOTFSMNT}"/etc/acpi/events
-  cp "${PLTDIR}/${DEVICE}"/utilities/acpi/events/mute-event "${ROOTFSMNT}"/etc/acpi/events
+  cp "${PLTDIR}/${DEVICE}"/utilities/acpi/events/brightness-button_event "${ROOTFSMNT}"/etc/acpi/events
+  cp "${PLTDIR}/${DEVICE}"/utilities/acpi/events/mute-button_event "${ROOTFSMNT}"/etc/acpi/events
   
 }
 

--- a/scripts/rootfs/volumioconfig.sh
+++ b/scripts/rootfs/volumioconfig.sh
@@ -451,6 +451,7 @@ log "Setting up wireless hostspot config" "info"
 log "Adding Volumio bits to dnsmasq and hostapd services"
 sed -i '/^After=network.target/a # For Volumio hotspot functionality\nAfter=hostapd.service\nPartOf=hostapd.service' /lib/systemd/system/dnsmasq.service
 sed -i '/^After=network.target/a # For Volumio hotspot functionality\nWants=dnsmasq.service' /lib/systemd/system/hostapd.service
+sed -i '/^After=network.target/a # Ensure rfkill unblocking before hostapd starts\nAfter=volumio_rfkill_unblock.service\nWants=volumio_rfkill_unblock.service' /lib/systemd/system/hostapd.service
 
 log "Configuring dnsmasq"
 # TODO listen on wlan* or only wlan0?


### PR DESCRIPTION
- Added Wants= and After= for volumio_rfkill_unblock.service to hostapd.service
- Maintains existing build-time customization style using sed
- Ensures Wi-Fi soft block is cleared before access point initialization
- Prevents hostapd startup failure due to rfkill state on early boot
