### PR TITLE
fix for failing armv7 builds, due to wrong configuration for upmpdcli

### DIFF
--- a/recipes/base/armv7.conf
+++ b/recipes/base/armv7.conf
@@ -1,7 +1,7 @@
 [General]
 include=VolumioBase.conf
 # only pick what we need from VolumioBase
-debootstrap=Accessories Assets Base BaseDebPlus Bluetooth FS Firmware Net UPnP Utils Volumio
+debootstrap=Accessories Assets Base BaseDebPlus Bluetooth FS Firmware Net Utils Volumio
 # debootstrap=UpmpdcliDependencies ShairportSyncDependencies
 # Add additional armv7 specific packages (if required)
 


### PR DESCRIPTION
Fix for failing armv7 builds. it was used the general configuration from VolumioBase.conf, pointing to the wrong repo for the upmpdcli package.

Now it makes use of the proper configuration from the armv7.conf file.