### PR TITLE
[kiosk mode] - Use GitHub-hosted Chromium packages by architecture for kiosk setup

### DIFF
--- a/recipes/base/VolumioBase.conf
+++ b/recipes/base/VolumioBase.conf
@@ -92,7 +92,8 @@ keyring=debian-archive-keyring
 suite=bookworm
 
 [Kiosk]
-packages=chromium chromium-l10n fonts-arphic-gbsn00lp fonts-arphic-ukai fonts-unfonts-core openbox unclutter xinit xorg
+# packages=chromium chromium-l10n
+packages=fonts-arphic-gbsn00lp fonts-arphic-ukai fonts-unfonts-core openbox unclutter xinit xorg
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=bookworm

--- a/scripts/components/install-kiosk-legacy-chromium.sh
+++ b/scripts/components/install-kiosk-legacy-chromium.sh
@@ -9,57 +9,27 @@ log "Installing $CMP_NAME" "ext"
 source /etc/os-release
 export DEBIAN_FRONTEND=noninteractive
 
-# Dependency packages
+# Some (more) raspbian specific schenanigans
+BrowerPckg="chromium"
+[[ ${ID} == raspbian ]] && BrowerPckg+="-browser"
 CMP_PACKAGES=(
   # Keyboard config
   "keyboard-configuration"
   # Display stuff
-  "openbox" "unclutter" "xorg" "xinit" "xinput"
+  "openbox" "unclutter" "xorg" "xinit"
+  # Browser
+  # TODO: Why not firefox? it seems to work OTB on most devices with less hassle?
+  "${BrowerPckg}" "chromium-l10n"
   # Fonts
   "fonts-arphic-ukai" "fonts-arphic-gbsn00lp" "fonts-unfonts-core"
   # Fonts for Japanese and Thai languages
   "fonts-ipafont" "fonts-vlgothic" "fonts-thai-tlwg-ttf"
-  # Chromium dependencies
-  "libgtk-3-0" "libxnvctrl0" "xdg-utils"
 )
 
 log "Installing ${#CMP_PACKAGES[@]} ${CMP_NAME} packages:" "" "${CMP_PACKAGES[*]}"
 apt-get install -y "${CMP_PACKAGES[@]}" --no-install-recommends
 
 log "${CMP_NAME} Dependencies installed!"
-
-# Browser
-ARCH=$(dpkg --print-architecture)
-log "${CMP_NAME} Detected architecture: $ARCH"
-# GITHUB_BASE_URL="https://github.com/volumio/volumio3-os-static-assets/raw/master/browsers/chromium"
-GITHUB_BASE_URL="https://github.com/foonerd/volumio3-os-static-assets/raw/master/browsers/chromium"
-declare -A DEB_FILES
-  DEB_FILES["chromium"]="chromium_135.0.7049.95-1~deb12u1_${ARCH}.deb"
-  DEB_FILES["chromium-common"]="chromium-common_135.0.7049.95-1~deb12u1_${ARCH}.deb"
-  DEB_FILES["chromium-l10n"]="chromium-l10n_135.0.7049.95-1~deb12u1_all.deb"
-
-TMP_DEB_DIR="/tmp/volumio-chromium"
-mkdir -p "$TMP_DEB_DIR"
-
-for pkg in chromium-common chromium chromium-l10n; do
-  DEB_NAME="${DEB_FILES[$pkg]}"
-  URL="$GITHUB_BASE_URL/$DEB_NAME"
-  DEST="$TMP_DEB_DIR/$DEB_NAME"
-  log "Downloading $pkg from $URL"
-  curl -L -o "$DEST" "$URL"
-  dpkg -i "$DEST" || apt-get install -f -y
-done
-log "${CMP_NAME} Cleaning up downloaded .deb files"
-rm -rf "$TMP_DEB_DIR"
-log "${CMP_NAME} Browser installed!"
-
-log "Creating ${CMP_NAME} Policy to Enable Manifest V2"
-mkdir -p /etc/chromium/policies/managed
-cat <<-EOF >/etc/chromium/policies/managed/policies.json
-{
-  "ExtensionManifestV2Availability": 2
-}
-EOF
 
 log "Creating ${CMP_NAME} dirs and scripts"
 mkdir /data/volumiokiosk
@@ -91,8 +61,6 @@ CHROMIUM_FLAGS=(
   "--disable-quic"
   "--enable-fast-unload"
   "--enable-tcp-fast-open"
-  "--autoplay-policy=no-user-gesture-required"
-  "--load-extension='/data/volumiokioskextensions/VirtualKeyboard/'"
 )
 
 if [[ ${BUILD:0:3} != 'arm' ]]; then
@@ -109,7 +77,6 @@ if [[ ${BUILD:0:3} != 'arm' ]]; then
 fi
 
 log "Adding ${#CHROMIUM_FLAGS[@]} Chromium flags"
-
 #TODO: Instead of all this careful escaping, make a simple template and add in CHROMIUM_FLAGS?
 cat <<-EOF >/opt/volumiokiosk.sh
 #!/usr/bin/env bash
@@ -138,7 +105,6 @@ export DISPLAY=:0
 
 xset -dpms
 xset s off
-
 [[ -e /data/volumiokiosk/Default/Preferences ]] && {
   sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' /data/volumiokiosk/Default/Preferences
   sed -i 's/"exit_type":"Crashed"/"exit_type":"None"/' /data/volumiokiosk/Default/Preferences
@@ -154,17 +120,16 @@ if [ ! -f /data/volumiokiosk/firststartdone ]; then
   touch /data/volumiokiosk/firststartdone
 fi
 
+
 # Wait for Volumio webUI to be available
 while true; do timeout 5 bash -c "</dev/tcp/127.0.0.1/3000" >/dev/null 2>&1 && break; done
 echo "Waited \$((\$(date +%s) - start)) sec for Volumio UI"
 
-# Start Openbox
 openbox-session &
   /usr/bin/chromium \\
 	$(printf '    %s \\\n' "${CHROMIUM_FLAGS[@]}")
     http://localhost:3000
 EOF
-
 chmod +x /opt/volumiokiosk.sh
 
 log "Creating Systemd Unit for ${CMP_NAME}"
@@ -178,24 +143,18 @@ Type=simple
 User=root
 Group=root
 ExecStart=/usr/bin/startx /etc/X11/Xsession /opt/volumiokiosk.sh -- -keeptty
-Restart=always
-RestartSec=5
 [Install]
 WantedBy=multi-user.target
 EOF
 
 log "Enabling ${CMP_NAME} service"
-ln -sf /lib/systemd/system/volumio-kiosk.service /etc/systemd/system/multi-user.target.wants/volumio-kiosk.service
+ln -s /lib/systemd/system/volumio-kiosk.service /etc/systemd/system/multi-user.target.wants/volumio-kiosk.service
 
 log "Setting localhost"
 echo '{"localhost": "http://127.0.0.1:3000"}' >/volumio/http/www/app/local-config.json
 if [ -d "/volumio/http/www3" ]; then
   echo '{"localhost": "http://127.0.0.1:3000"}' >/volumio/http/www3/app/local-config.json
 fi
-
-log "Installing ${CMP_NAME} Virtual Keyboard"
-mkdir /data/volumiokioskextensions
-git clone https://github.com/volumio/chrome-virtual-keyboard.git /data/volumiokioskextensions/VirtualKeyboard
 
 if [[ ${VOLUMIO_HARDWARE} != motivo ]]; then
 


### PR DESCRIPTION
This PR replaces APT-based Chromium installation with a version-specific, architecture-aware approach using GitHub-hosted .deb packages. It resolves issues caused by package version mismatches and missing dependencies on Debian 12.

Changes include:
- Dynamic selection of chromium, chromium-common, and chromium-l10n based on detected architecture
- Download to and cleanup from a temporary directory
- Compatibility maintained with Debian 12 library versions
- Prepares the kiosk script for consistent behavior across devices
