### PR TITLE
 Optimize Samba Systemd Startup Order with Override Units

### DIFF
--- a/scripts/rootfs/configure.sh
+++ b/scripts/rootfs/configure.sh
@@ -115,10 +115,19 @@ for path in "${SRC}"/volumio/lib/systemd/system/*.path; do
   cp  "${path}" "${ROOTFS}"/lib/systemd/system/
 done
 
-log "Override alsa-restore systemd services" "info"
-mkdir -p "${ROOTF}"/etc/systemd/system/alsa-restore.service.d
-cp "${SRC}/volumio/etc/systemd/system/alsa-restore.service.d/override.conf" "${ROOTFS}/etc/systemd/system/alsa-restore.service.d/override.conf"
+log 'Done Copying Custom Volumio System Files' "okay"
+
+#VOLUMIO SERVICES OVERRIDE
+log "Volumio Service Overrides" "info"
+for override in "${SRC}"/volumio/etc/systemd/system/*/*.conf; do
+  log "Copying ${override}"
+  relpath="${override#${SRC}/volumio/}"  # strip leading prefix
+  mkdir -p "${ROOTFS}/$(dirname "${relpath}")"
+  cp "${override}" "${ROOTFS}/${relpath}"
+done
+
+# ALSA RESTORE OVERRIDE HELPER SCRIPT
 cp -rp "${SRC}/volumio/bin/wait-for-cards.sh" "${ROOTFS}/usr/bin/wait-for-cards.sh"
 chmod a+x "${ROOTFS}/usr/bin/wait-for-cards.sh"
 
-log 'Done Copying Custom Volumio System Files' "okay"
+log 'Done Volumio Service Overrides' "okay"

--- a/volumio/etc/systemd/system/nmbd.service.d/override.conf
+++ b/volumio/etc/systemd/system/nmbd.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=winbind.service
+Requires=winbind.service

--- a/volumio/etc/systemd/system/winbind.service.d/override.conf
+++ b/volumio/etc/systemd/system/winbind.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=network-online.target smbd.service
+Requires=network-online.target smbd.service


### PR DESCRIPTION
This PR introduces systemd override files to ensure correct and efficient startup sequencing for Samba-related services:

* `winbind.service` now explicitly starts *after* `smbd.service` and `network-online.target`
* `nmbd.service` starts *after* `winbind.service`

These changes prevent premature invocation of network-dependent components and help reduce early boot-time blocking caused by DNS, DHCP, or delayed link-up. Overrides are placed in:

```
/etc/systemd/system/winbind.service.d/override.conf
/etc/systemd/system/nmbd.service.d/override.conf
```

This improves reliability across both wired and wireless Volumio deployments.
