### PR TITLE
 Ensure Volumio Service Starts After ALSA Restore

### DIFF
--- a/volumio/etc/systemd/system/volumio.service.d/override.conf
+++ b/volumio/etc/systemd/system/volumio.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=alsa-restore.service
+Requires=alsa-restore.service


### PR DESCRIPTION
This PR adds a systemd override for `volumio.service` to enforce proper startup order by requiring:

```
After=alsa-restore.service
Requires=alsa-restore.service
```

This ensures the Volumio backend does not start before the ALSA state is restored and all sound cards are initialized. It prevents race conditions with mixer access and guarantees a stable audio environment at boot.

The override is installed at:

```
/etc/systemd/system/volumio.service.d/override.conf
```
