### PR TITLE
Update udev rule to reliably restart triggerhappy on Bluetooth HID device connection

### DIFF
--- a/volumio/etc/udev/rules.d/99-restart-thd-on-hid.rules
+++ b/volumio/etc/udev/rules.d/99-restart-thd-on-hid.rules
@@ -1,0 +1,3 @@
+# This udev rule restarts the triggerhappy service when a Bluetooth HID device is added or removed.
+ACTION=="add", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_BUS}=="bluetooth", RUN+="/bin/systemctl restart triggerhappy"
+ACTION=="remove", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_BUS}=="bluetooth", RUN+="/bin/systemctl restart triggerhappy"


### PR DESCRIPTION
- Replaced ATTRS{phys} match with ENV{ID_BUS}=="bluetooth" for broader compatibility
- Ensures triggerhappy is restarted when new Bluetooth input devices are added via uhid
- Resolves issue where BlueZ HID devices (e.g., remotes, keyboards) were not functional until manual service restart
