### PR TITLE
Fix - triggerhappy: improve input device binding and Bluetooth HID handling

### DIFF
--- a/scripts/rootfs/configure.sh
+++ b/scripts/rootfs/configure.sh
@@ -77,9 +77,12 @@ cp "${SRC}/volumio/bin/firststart.sh" "${ROOTFS}/bin/firststart.sh"
 #dynswap
 cp "${SRC}/volumio/bin/dynswap.sh" "${ROOTFS}/bin/dynswap.sh"
 
-#udev script
+#udev scripts
 cp "${SRC}/volumio/bin/rename_netiface0.sh" "${ROOTFS}/bin/rename_netiface0.sh"
 chmod a+x "${ROOTFS}/bin/rename_netiface0.sh"
+
+cp "${SRC}/volumio/bin/th-udev-rebind.sh" "${ROOTFS}/bin/th-udev-rebind.sh"
+chmod a+x "${ROOTFS}/bin/th-udev-rebind.sh"
 
 #Plymouth & upmpdcli files
 cp -rp "${SRC}"/volumio/usr/* "${ROOTFS}/usr/"

--- a/scripts/rootfs/volumioconfig.sh
+++ b/scripts/rootfs/volumioconfig.sh
@@ -372,14 +372,6 @@ ln -s /lib/systemd/system/volumiossh.service /etc/systemd/system/multi-user.targ
 log "Enable Volumio IP Change Monitoring Service"
 ln -s /lib/systemd/system/volumio-ipchange.service /etc/systemd/system/multi-user.target.wants/volumio-ipchange.service
 
-log "Enable Volumio Triggerhappy Rebind Service"
-ln -s /lib/systemd/system/th-udev-rebind.service /etc/systemd/system/multi-user.target.wants/th-udev-rebind.service
-
-log "Mute Default Triggerhappy udev rule"
-# This is to prevent triggerhappy from triggering on udev events before sockets are created
-# and before the triggerhappy service is started.
-ln -s /dev/null /etc/udev/rules.d/60-triggerhappy.rules
-
 log "Enable Volumio Welcome Service"
 ln -s /lib/systemd/system/welcome.service /etc/systemd/system/multi-user.target.wants/welcome.service
 
@@ -564,4 +556,19 @@ log "Enable time sync helper and watchdog"  "info"
 ln -s /lib/systemd/system/setdatetime-helper.service /etc/systemd/system/multi-user.target.wants/setdatetime-helper.service
 ln -s /lib/systemd/system/setdatetime-helper.timer /etc/systemd/system/timers.target.wants/setdatetime-helper.timer
 
+#####################
+#UDEV RULES#----------------------------------------
+#####################
+log "Fixing mismatched udev rules"  "info"
+log "Enable Volumio Triggerhappy Rebind Service"
+ln -s /lib/systemd/system/th-udev-rebind.service /etc/systemd/system/multi-user.target.wants/th-udev-rebind.service
 
+log "Mute Default Triggerhappy udev rule"
+# This is to prevent triggerhappy from triggering on udev events before sockets are created
+# and before the triggerhappy service is started.
+ln -s /dev/null /etc/udev/rules.d/60-triggerhappy.rules
+
+log "Mute Default HCI udev rule"
+# AutoEnable=true in /etc/bluetooth/main.conf confirms that BlueZ will automatically power up hci0 when bluetoothd starts.
+rm /etc/udev/rules.d/10-local.rules
+ln -s /dev/null /etc/udev/rules.d/10-local.rules

--- a/scripts/rootfs/volumioconfig.sh
+++ b/scripts/rootfs/volumioconfig.sh
@@ -372,6 +372,14 @@ ln -s /lib/systemd/system/volumiossh.service /etc/systemd/system/multi-user.targ
 log "Enable Volumio IP Change Monitoring Service"
 ln -s /lib/systemd/system/volumio-ipchange.service /etc/systemd/system/multi-user.target.wants/volumio-ipchange.service
 
+log "Enable Volumio Triggerhappy Rebind Service"
+ln -s /lib/systemd/system/th-udev-rebind.service /etc/systemd/system/multi-user.target.wants/th-udev-rebind.service
+
+log "Mute Default Triggerhappy udev rule"
+# This is to prevent triggerhappy from triggering on udev events before sockets are created
+# and before the triggerhappy service is started.
+ln -s /dev/null /etc/udev/rules.d/60-triggerhappy.rules
+
 log "Enable Volumio Welcome Service"
 ln -s /lib/systemd/system/welcome.service /etc/systemd/system/multi-user.target.wants/welcome.service
 

--- a/volumio/bin/th-udev-rebind.sh
+++ b/volumio/bin/th-udev-rebind.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+timeout=5
+while [ ! -S /run/thd.socket ] && [ $timeout -gt 0 ]; do
+  sleep 0.5
+  timeout=$((timeout - 1))
+done
+
+for dev in /dev/input/event*; do
+  /usr/sbin/th-cmd --socket /run/thd.socket --passfd --udev < "$dev"
+done

--- a/volumio/etc/triggerhappy/triggers.d/audio.conf
+++ b/volumio/etc/triggerhappy/triggers.d/audio.conf
@@ -1,20 +1,26 @@
 #VOLUMIO TRIGGERHAPPY CONFIGURATION FILE
 
 #MUTE TOGGLE
-KEY_MIN_INTERESTING 1 /usr/local/bin/volumio volume toggle
-
+KEY_MUTE 1 /usr/local/bin/volumio volume toggle
+#
 #VOLUME UP
 KEY_VOLUMEUP 1 /usr/local/bin/volumio volume plus
-
+#
 #VOLUME DOWN
 KEY_VOLUMEDOWN 1 /usr/local/bin/volumio volume minus
-
+#
+#STOP
+KEY_STOP 1 /usr/local/bin/volumio stop
+#
+#START
+KEY_PLAY 1 /usr/local/bin/volumio play
+#
 #PLAY PAUSE TOGGLE
 KEY_PLAYPAUSE 1 /usr/local/bin/volumio toggle
-
+#
 #NEXT
 KEY_NEXTSONG 1 /usr/local/bin/volumio next
-
+#
 #PREVIOUS
 KEY_PREVIOUSSONG 1 /usr/local/bin/volumio previous
 

--- a/volumio/etc/udev/rules.d/59-triggerhappy-socket.rules
+++ b/volumio/etc/udev/rules.d/59-triggerhappy-socket.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="input", ATTRS{name}!="triggerhappy", ENV{SYSTEMD_WANTS}="triggerhappy.socket"

--- a/volumio/etc/udev/rules.d/99-restart-thd-on-hid.rules
+++ b/volumio/etc/udev/rules.d/99-restart-thd-on-hid.rules
@@ -1,0 +1,3 @@
+# This udev rule restarts the triggerhappy service when a Bluetooth HID device is added or removed.
+ACTION=="add", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_BUS}=="bluetooth", RUN+="/bin/systemctl restart triggerhappy"
+ACTION=="remove", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_BUS}=="bluetooth", RUN+="/bin/systemctl restart triggerhappy"

--- a/volumio/lib/systemd/system/th-udev-rebind.service
+++ b/volumio/lib/systemd/system/th-udev-rebind.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Late rebind of input devices to triggerhappy
+After=triggerhappy.socket triggerhappy.service
+Requires=triggerhappy.socket
+
+[Service]
+Type=oneshot
+ExecStart=/bin/th-udev-rebind.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/volumio/lib/systemd/system/triggerhappy.service
+++ b/volumio/lib/systemd/system/triggerhappy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=triggerhappy global hotkey daemon
+Requires=triggerhappy.socket
+After=triggerhappy.socket local-fs.target
+
+[Service]
+Type=notify
+ExecStart=/usr/sbin/thd --triggers /etc/triggerhappy/triggers.d/ --socket /run/thd.socket --user nobody --deviceglob /dev/input/event*
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This MR resolves Bluetooth HID remotes and keyboards becoming inoperable after pairing due to missed triggerhappy input bindings. It introduces a set of coordinated changes:

- Added a universal udev rule: 99-restart-thd-on-hid.rules
  - Automatically restarts triggerhappy when a Bluetooth HID input device is added or removed
  - Uses ENV{ID_BUS}=="bluetooth" for better device match coverage

- Added systemd service: th-udev-rebind.service
  - Defers rebinding of input devices to triggerhappy until its socket is ready
  - Handles race condition between udev and systemd socket activation

- Masked upstream udev rules that conflicted with orderly device handling:
  - 60-triggerhappy.rules now points to /dev/null
  - 10-local.rules for HCI autostart also muted (BlueZ AutoEnable is sufficient)

- Rebased triggerhappy trigger file (`audio.conf`) for more consistent formatting and added stop/play mappings

- Integrated all required scripts and systemd units into the rootfs image:
  - th-udev-rebind.sh installed to /bin and made executable
  - th-udev-rebind.service enabled at multi-user.target

This enables seamless use of Bluetooth remotes without requiring manual triggerhappy restarts.

