### PR TITLE
triggerhappy: switch to service-only mode with explicit rebind

### DIFF
--- a/scripts/rootfs/volumioconfig.sh
+++ b/scripts/rootfs/volumioconfig.sh
@@ -557,7 +557,7 @@ ln -s /lib/systemd/system/setdatetime-helper.service /etc/systemd/system/multi-u
 ln -s /lib/systemd/system/setdatetime-helper.timer /etc/systemd/system/timers.target.wants/setdatetime-helper.timer
 
 #####################
-#UDEV RULES#----------------------------------------
+#UDEV RULES#-----------------------------------------
 #####################
 log "Fixing mismatched udev rules"  "info"
 log "Enable Volumio Triggerhappy Rebind Service"
@@ -567,3 +567,10 @@ log "Mute Default Triggerhappy udev rule"
 # This is to prevent triggerhappy from triggering on udev events before sockets are created
 # and before the triggerhappy service is started.
 ln -s /dev/null /etc/udev/rules.d/60-triggerhappy.rules
+
+#####################
+#TRIGGER HAPPY broken socket#------------------------
+#####################
+log "Disable and mask triggerhappy.socket"
+systemctl disable triggerhappy.socket
+ln -sf /dev/null /etc/systemd/system/sockets.target.wants/triggerhappy.socket

--- a/volumio/bin/th-udev-rebind.sh
+++ b/volumio/bin/th-udev-rebind.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
-timeout=5
+# Wait up to 5 seconds for the socket to appear
+timeout=10
 while [ ! -S /run/thd.socket ] && [ $timeout -gt 0 ]; do
   sleep 0.5
   timeout=$((timeout - 1))
 done
 
+if [ ! -S /run/thd.socket ]; then
+  echo "Error: thd.socket not found after timeout"
+  exit 1
+fi
+
+# Enumerate and rebind all input event devices
 for dev in /dev/input/event*; do
-  /usr/sbin/th-cmd --socket /run/thd.socket --passfd --udev < "$dev"
+  if [ -r "$dev" ]; then
+    echo "Rebinding $dev to thd using --add..."
+    /usr/sbin/th-cmd --socket /run/thd.socket --passfd --add "$dev"
+  fi
 done

--- a/volumio/lib/systemd/system/th-udev-rebind.service
+++ b/volumio/lib/systemd/system/th-udev-rebind.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Late rebind of input devices to triggerhappy
-After=triggerhappy.socket triggerhappy.service
-Requires=triggerhappy.socket
+After=triggerhappy.service
+Wants=triggerhappy.service
 
 [Service]
 Type=oneshot

--- a/volumio/lib/systemd/system/triggerhappy.service
+++ b/volumio/lib/systemd/system/triggerhappy.service
@@ -1,11 +1,10 @@
 [Unit]
 Description=triggerhappy global hotkey daemon
-Requires=triggerhappy.socket
-After=triggerhappy.socket local-fs.target
+After=local-fs.target
 
 [Service]
 Type=notify
-ExecStart=/usr/sbin/thd --triggers /etc/triggerhappy/triggers.d/ --socket /run/thd.socket --user nobody --deviceglob /dev/input/event*
+ExecStart=/usr/sbin/thd --triggers /etc/triggerhappy/triggers.d/ --socket /run/thd.socket --user nobody --deviceglob "/dev/input/event*"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Regression:

- Fixes segmentation fault and "Transport endpoint is not connected" errors
- Updated triggerhappy.service to use --socket explicitly with --deviceglob
- Disabled triggerhappy.socket to avoid systemd socket activation conflicts
