### PR TITLE
smb - race condition regression

### DIFF
--- a/volumio/etc/systemd/system/nmbd.service.d/override.conf
+++ b/volumio/etc/systemd/system/nmbd.service.d/override.conf
@@ -1,3 +1,0 @@
-[Unit]
-After=winbind.service
-Requires=winbind.service

--- a/volumio/etc/systemd/system/smbd.service.d/override.conf
+++ b/volumio/etc/systemd/system/smbd.service.d/override.conf
@@ -1,2 +1,0 @@
-[Service]
-ExecStartPre=/bin/mkdir -m 700 -p /var/log/samba/cores

--- a/volumio/etc/systemd/system/winbind.service.d/override.conf
+++ b/volumio/etc/systemd/system/winbind.service.d/override.conf
@@ -1,3 +1,0 @@
-[Unit]
-After=network-online.target smbd.service
-Requires=network-online.target smbd.service


### PR DESCRIPTION
We gained only 2 sec in boot, bu expense of race condition.

Discarding https://github.com/volumio/volumio-os/pull/185 and https://github.com/volumio/volumio-os/pull/195