### PR TITLE
Fix boot issues on Pi by removing unintended +rpt-rpi-* kernel module directories

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -61,8 +61,8 @@ RpiRepo="https://github.com/raspberrypi/rpi-firmware"
 RpiUpdateRepo="raspberrypi/rpi-update"
 ## We ended with 10 versions od 6.12.34 kernels from master branch.
 ## Using older branch to avoid boot failures
-# RpiUpdateBranch="master"
-RpiUpdateBranch="1dd909e2c8c2bae7adb3eff3aed73c3a6062e8c8"
+RpiUpdateBranch="master"
+# RpiUpdateBranch="1dd909e2c8c2bae7adb3eff3aed73c3a6062e8c8"
 
 declare -A PI_KERNELS=(
 	#[KERNEL_VERSION]="SHA|Branch|Rev"
@@ -202,7 +202,8 @@ device_image_tweaks() {
 	log "Fetching SHA: ${KERNEL_COMMIT} from branch: ${KERNEL_BRANCH}" "info"
 	RpiUpdate_args=("UPDATE_SELF=0" "ROOT_PATH=${ROOTFSMNT}" "BOOT_PATH=${ROOTFSMNT}/boot"
 		"SKIP_WARNING=1" "SKIP_BACKUP=1" "SKIP_CHECK_PARTITION=1"
-		"WANT_32BIT=1" "WANT_64BIT=1" "WANT_PI4=1" "WANT_PI5=1" "WANT_16K=0"
+		"WANT_32BIT=1" "WANT_64BIT=1" "WANT_PI2=1" "WANT_PI4=1"
+		"WANT_PI5=1" "WANT_16K=0" "WANT_64BIT_RT=0"
 		# "BRANCH=${KERNEL_BRANCH}"
 	)
 	env "${RpiUpdate_args[@]}" "${ROOTFSMNT}"/usr/bin/rpi-update "${KERNEL_COMMIT}"
@@ -246,19 +247,39 @@ device_chroot_tweaks_pre() {
 		[PiCustom]="https://raw.githubusercontent.com/Darmur/volumio-rpi-custom/main/output/modules-rpi-${KERNEL_VERSION}-custom.tar.gz"
 	)
 
-	## Comment to keep RPi4/RPi5 64bit kernel
-	#if [ -d "/lib/modules/${KERNEL_VERSION}-v8+" ]; then
-	#	log "Removing v8+ (Pi4/5) Kernel and modules" "info"
-	#	rm -rf /boot/kernel8.img
-	#	rm -rf "/lib/modules/${KERNEL_VERSION}-v8+"
-	#fi
+	# Define the kernel version (already parsed earlier)
 
-	## Comment to keep RPi5 64bit 16k page size kernel
+	# Remove Pi5 16K kernel
 	if [[ -d "/lib/modules/${KERNEL_VERSION}-v8-16k+" ]]; then
 		log "Removing v8-16k+ (Pi5 16k) Kernel and modules" "info"
-		rm -rf /boot/kernel_2712.img
+		rm -f /boot/kernel_2712.img
 		rm -rf "/lib/modules/${KERNEL_VERSION}-v8-16k+"
 	fi
+
+	# Remove 64-bit realtime kernel
+	if [[ -d "/lib/modules/${KERNEL_VERSION}-v8-rt+" ]]; then
+		log "Removing v8-rt+ (64bit RT) Kernel and modules" "info"
+		rm -f /boot/kernel_2712_rt.img
+		rm -rf "/lib/modules/${KERNEL_VERSION}-v8-rt+"
+	fi
+
+	# Remove all unintended +rpt-rpi-* variants
+	for kdir in /lib/modules/*; do
+		kbase=$(basename "$kdir")
+		if [[ "$kbase" == *+rpt-rpi-* ]]; then
+			log "Removing stray kernel module folder: $kbase" "info"
+			rm -rf "/lib/modules/$kbase"
+		fi
+	done
+
+	# Optional: remove any empty module folders
+	for kdir in /lib/modules/${KERNEL_VERSION}*; do
+		if [[ -d "$kdir" && ! -f "$kdir/modules.builtin" ]]; then
+			kbase=$(basename "$kdir")
+			log "Removing empty kernel module folder: $kbase" "info"
+			rm -rf "$kdir"
+		fi
+	done
 
 	log "Finished Kernel installation" "okay"
 
@@ -531,6 +552,16 @@ device_chroot_tweaks_pre() {
 	cat <<-EOF >/boot/cmdline.txt
 		${kernel_params[@]}
 	EOF
+
+	log "Final cleanup: remove unintended +rpt-rpi-* kernel module folders" "info"
+	for kdir in /lib/modules/*+rpt-rpi-*; do
+		if [[ -d "$kdir" ]]; then
+			kbase=$(basename "$kdir")
+			log "Removing final-stage rpt-rpi kernel module folder:" "$kbase" "info"
+			rm -rf "$kdir"
+		fi
+	done
+	log "Raspi Kernel and Modules cleanup completed" "okay"
 
 	log "Finalise all kernels with depmod and other tricks" "info"
 	# https://www.raspberrypi.com/documentation/computers/linux_kernel.html


### PR DESCRIPTION
This PR resolves a critical regression affecting Volumio Bookworm BETA builds using kernel 6.12.34 on Raspberry Pi.

Problem:
- Stray module directories like 6.12.34+rpt-rpi-2712, +rpt-rpi-v6, etc., were being created but not populated, causing depmod warnings and in some cases breaking the boot process, especially on Raspberry Pi 5.

Fix:
- Explicitly remove any /lib/modules/*+rpt-rpi-* directories prior to depmod and initramfs generation.
- Confirmed working on Pi5dev with clean boot.

This regression was introduced in the past week and did not affect earlier builds such as 4.017.
