### PR TITLE
[x86.sh] A "slow" x86 confguration may need more time to initialise USB

### DIFF
--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -267,6 +267,8 @@ device_chroot_tweaks_pre() {
 
   # Build up the base parameters
   kernel_params+=(
+    # Boot delay
+	"bootdelay=5"
     # Bios stuff
     "biosdevname=0"
     # Boot params


### PR DESCRIPTION
e.g. DELL Wyse 5070