### PR TITLE
[pi] - kernel: harden cleanup to drop -16k

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -546,7 +546,7 @@ device_chroot_tweaks_pre() {
 	EOF
 
 	log "Final cleanup: remove unintended +rpt-rpi-* kernel module folders" "info"
-	for kdir in /lib/modules/*+rpt-rpi-*; do
+	for kdir in /lib/modules/*-16k+ /lib/modules/*+rpt-rpi-*; do
 		if [[ -d "$kdir" ]]; then
 			kbase=$(basename "$kdir")
 			log "Removing final-stage rpt-rpi kernel module folder:" "$kbase" "info"


### PR DESCRIPTION
Ensure final image only contains supported kernel variants (+, -v7+, -v7l+, -v8+).
Explicitly remove any -v8-16k+ module directory and skip incomplete
module trees during depmod. This prevents mkinitramfs from being invoked on
non-existent kernels and eliminates spurious warnings.