### PR TITLE
ci: fix shellcheck false positives from initramfs context

### DIFF
--- a/.github/workflows/shcheck.yml
+++ b/.github/workflows/shcheck.yml
@@ -4,14 +4,13 @@ name: Check and format
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events for all branches
-  push:
-    branches-ignore:
-      - 'dependabot/**'
+  # Only run on pull requests - not on every push
+  # This prevents false positives from shellcheck not understanding
+  # initramfs runtime context (sourced files, preset variables)
   pull_request:
     types: [opened, synchronize, reopened]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows manual runs from Actions tab for testing
   workflow_dispatch:
 
 env:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,19 @@
+# Shellcheck configuration for Volumio OS build system
+#
+# This build system includes initramfs scripts that run in a different
+# context than where shellcheck analyzes them. At boot time:
+# - /scripts/functions exists (provided by initramfs-tools)
+# - /scripts/volumio-functions exists (copied during build)
+# - Variables like rootmnt, BOOT, etc. are set by initramfs infrastructure
+
+# SC1090: Can't follow non-constant source
+# Reason: initramfs sources files dynamically
+disable=SC1090
+
+# SC1091: Not following sourced file (file not found)
+# Reason: /scripts/* paths exist at boot, not in repo
+disable=SC1091
+
+# SC2154: Variable referenced but not assigned
+# Reason: initramfs infrastructure sets rootmnt, BOOT, ROOT, etc.
+disable=SC2154


### PR DESCRIPTION
- Remove push trigger from shcheck.yml (PR-only checking)
- Add .shellcheckrc to suppress SC1090, SC1091, SC2154
- These codes flag initramfs runtime paths and variables that exist at boot but not in the repository