### PR TITLE
fix(upmpdcli): add restart policy to handle port binding race condition

### DIFF
--- a/volumio/lib/systemd/system/upmpdcli.service
+++ b/volumio/lib/systemd/system/upmpdcli.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=UPnP Renderer front-end to MPD
-After=syslog.target mpd.service
+After=syslog.target
 
 [Service]
 Type=simple
@@ -9,6 +9,7 @@ User=volumio
 Group=volumio
 Restart=always
 RestartSec=15s
+TimeoutStopSec=10
 TimeoutStartFailureMode=terminate
 TimeoutStopFailureMode=terminate
 


### PR DESCRIPTION
upmpdcli service fails on restart with "port 6690 busy unable to bind"
when old process has not fully released the UPnP HTTP server port before
new instance attempts to bind.

Root cause: missing restart directives in service file. Upstream
lesbonscomptes packaging includes Restart=always with explicit comment
noting this requirement.

Changes:
- Add Restart=always to retry after transient failures
- Add RestartSec=15s to allow socket TIME_WAIT cleanup
- Add TimeoutStopSec=10 for clean shutdown window
- Add TimeoutStartFailureMode=terminate for stuck process handling
- Add TimeoutStopFailureMode=terminate for stuck process handling

Note: mpd.service dependency not required - upmpdcli 1.9.7 has internal
retry loops for both MPD connectivity (src/main.cxx:717-735) and network
availability (src/main.cxx:668-683).

Tested: service now recovers reliably on restart cycles.