### PR TITLE
fix(dhcpcd): add missing hostname and ntp_servers directives

### DIFF
--- a/volumio/etc/dhcpcd.conf
+++ b/volumio/etc/dhcpcd.conf
@@ -1,98 +1,14 @@
-#===================================================================
-# Volumio DHCP Client Daemon Configuration
-# Maintainer: Just a Nerd
-# Version: 1.0
-# Date: 2025-11-14
-#
-# This configuration manages DHCP client behavior for Volumio's
-# network interfaces (eth0, wlan0). Settings are optimized for
-# embedded audio streaming systems with wireless networking.
-#
-# For detailed option descriptions, see: dhcpcd.conf(5)
-#===================================================================
-
-#===================================================================
-# INTERFACE MANAGEMENT
-#===================================================================
-
-# Restrict dhcpcd to ethernet and WiFi interfaces only
-# Prevents dhcpcd from managing other network devices
 allowinterfaces eth0 wlan0
-
-#===================================================================
-# CLIENT IDENTIFICATION
-#===================================================================
-
-# Use DHCP Unique Identifier (DUID) + Interface Association ID (IAID)
-# per RFC4361 for consistent client identification across reboots
-# Note: Some non-compliant DHCP servers may not support this
+hostname
 duid
-
-# Blank vendor class identifier to avoid advertising system details
-# Default would send: dhcpcd-<version>:<os>:<machine>:<platform>
 vendorclassid
-
-#===================================================================
-# LEASE PERSISTENCE
-#===================================================================
-
-# Keep interface configuration active when dhcpcd exits
-# Prevents network disruption during dhcpcd service restarts
 persistent
-
-#===================================================================
-# DHCP OPTIONS
-#===================================================================
-
-# Request DNS and domain information from DHCP server
-option domain_name_servers, domain_name, domain_search
-
-# Request classless static routes (RFC 3442)
-# Allows DHCP server to provide custom routing information
+option domain_name_servers, domain_name, domain_search, host_name
 option classless_static_routes
-
-# Respect network MTU settings from DHCP server
-# Applied to DHCP-configured routes
 option interface_mtu
-
-# Request hostname assignment from DHCP server
-option host_name
-
-# Enable rapid commit (RFC 4039)
-# Reduces DHCP handshake from 4 to 2 messages when server supports it
-# Safe to enable - only activates if server also supports it
 option rapid_commit
-
-#===================================================================
-# DHCP PROTOCOL REQUIREMENTS
-#===================================================================
-
-# Require DHCP server identifier in responses per RFC 2131
-# Ensures we know which DHCP server provided the lease
+option ntp_servers
 require dhcp_server_identifier
-
-#===================================================================
-# IPv6 CONFIGURATION
-#===================================================================
-
-# Use stable private IPv6 addresses based on DUID
-# Provides privacy while maintaining address stability
-# Alternative: 'slaac hwaddr' uses hardware address (less private)
 slaac private
-
-#===================================================================
-# IPv4 LINK-LOCAL DISABLE
-#===================================================================
-
-# Disable IPv4 link-local address assignment (169.254.x.x)
-# Volumio relies on proper DHCP or static configuration
-# Link-local addresses can cause confusion in audio streaming
 noipv4ll
-
-#===================================================================
-# HOSTNAME RESOLUTION
-#===================================================================
-
-# Disable hostname lookups via hook scripts
-# Reduces unnecessary DNS queries and startup delays
 nohook lookup-hostname


### PR DESCRIPTION
Add two directives missing from dhcpcd.conf that are present in backend:
- hostname: sends system hostname to DHCP server for DNS registration
- option ntp_servers: requests NTP server addresses from DHCP server

Aligns OS configuration with backend expected state.

Related to: https://github.com/volumio/volumio3-backend/pull/254