### PR TITLE
feat(pi): enable vc4-kms-v3d for all Pi models via firmware overlay mapping

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -661,11 +661,11 @@ device_chroot_tweaks_pre() {
 		dtoverlay=dwc2,dr_mode=host
 		otg_mode=1
 		[pi5]
-		dtoverlay=vc4-kms-v3d-pi5
 		# dtparam=uart0_console # Disabled by default
 		dtparam=nvme
 		dtparam=pciex1_gen=2
 		[all]
+		dtoverlay=vc4-kms-v3d
 		arm_64bit=0
 		dtparam=audio=on
 		audio_pwm_mode=2


### PR DESCRIPTION
Move dtoverlay=vc4-kms-v3d to [all] section in volumioconfig.txt,
leveraging firmware overlay_map.dtb for automatic hardware detection.

- Pi 0/1/2/3: loads vc4-kms-v3d
- Pi 4/CM4: loads vc4-kms-v3d-pi4  
- Pi 5/CM5: loads vc4-kms-v3d-pi5

Removes need for users to manually add KMS overlay to userconfig.txt.