### PR TITLE
fix: add nobody user to input group for triggerhappy

### DIFF
--- a/scripts/rootfs/volumioconfig.sh
+++ b/scripts/rootfs/volumioconfig.sh
@@ -626,7 +626,10 @@ log "Fixing mismatched udev rules"  "info"
 log "Enable Volumio Triggerhappy Rebind Service"
 ln -s /lib/systemd/system/th-udev-rebind.service /etc/systemd/system/multi-user.target.wants/th-udev-rebind.service
 
-log "Mute Default Triggerhappy udev rule"
+log "Adding nobody user to input group for triggerhappy"  "info"
+usermod -a -G input nobody
+
+log "Mute Default Triggerhappy udev rule"  "info"
 # This is to prevent triggerhappy from triggering on udev events before sockets are created
 # and before the triggerhappy service is started.
 ln -s /dev/null /etc/udev/rules.d/60-triggerhappy.rules
@@ -634,6 +637,6 @@ ln -s /dev/null /etc/udev/rules.d/60-triggerhappy.rules
 #####################
 #TRIGGER HAPPY broken socket#------------------------
 #####################
-log "Disable and mask triggerhappy.socket"
+log "Disable and mask triggerhappy.socket"  "info"
 systemctl disable triggerhappy.socket
 ln -sf /dev/null /etc/systemd/system/sockets.target.wants/triggerhappy.socket


### PR DESCRIPTION
USB HID input devices (FLIRC remotes, USB keyboards, HID remotes, DACs with HID controls) do not work through triggerhappy on Volumio 4 Bookworm.

The triggerhappy service runs as user `nobody` but this user is not a member of the `input` group. Input event devices have permissions `crw-rw---- root:input` (660), so triggerhappy cannot read any `/dev/input/event*` devices.

```
$ ls -la /dev/input/
crw-rw----  1 root input 13, 64 event0
crw-rw----  1 root input 13, 65 event1

$ groups nobody
nobody : nogroup
```

This causes a silent failure - triggerhappy starts successfully but cannot process any input events.

## Cause

In `volumio/lib/systemd/system/triggerhappy.service`:
```
ExecStart=/usr/sbin/thd --triggers /etc/triggerhappy/triggers.d/ --socket /run/thd.socket --user nobody --deviceglob "/dev/input/event*"
```

The `--user nobody` flag drops privileges to the `nobody` user, which lacks `input` group membership required to read input devices.

## Fix

Add `nobody` to the `input` group during image build in `scripts/rootfs/volumioconfig.sh`:

```bash
log "Adding nobody user to input group for triggerhappy"
usermod -a -G input nobody
```

This follows the existing pattern used for audio group membership (lines 458-459, 597-600).

## Affected Devices

- FLIRC USB receivers
- USB keyboards (media keys via triggerhappy)
- USB HID remotes (HiFiBerry wireless remote, air mouse remotes)
- DACs with HID controls (Audiolab M-DAC, others)
- Any device relying on triggerhappy for `/dev/input/event*` handling

## Related Issues

- GitHub volumio/volumio-os #343 (Audiolab M-DAC Consumer Control)
- Community reports: FLIRC USB not working after upgrade to Volumio 4
