### PR TITLE
feat: block raspi-config on Pi and CM4 images

### DIFF
--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -175,6 +175,10 @@ device_image_tweaks() {
 	curl -L --output "${ROOTFSMNT}/usr/bin/rpi-update" "https://raw.githubusercontent.com/${RpiUpdateRepo}/${RpiUpdateBranch}/rpi-update" &&
 		chmod +x "${ROOTFSMNT}/usr/bin/rpi-update"
 
+	log "Installing raspi-config blocker (Volumio OS does not support raspi-config)" "info"
+	cp "${SRC}/volumio/bin/raspi-config-disabled" "${ROOTFSMNT}/usr/bin/raspi-config"
+	chmod +x "${ROOTFSMNT}/usr/bin/raspi-config"
+
 	# For bleeding edge, check what is the latest on offer
 	# Things *might* break, so you are warned!
 	if [[ ${RPI_USE_LATEST_KERNEL:-no} == yes ]]; then
@@ -554,4 +558,11 @@ device_image_tweaks_post() {
 		log "Updating plymouth systemd services" "info"
 		cp -dR "${SRC}"/volumio/framebuffer/systemd/* "${ROOTFSMNT}"/lib/systemd
 	fi
+
+	log "Blocking raspi-config package (Volumio OS does not support raspi-config)" "info"
+	cat <<-EOF >"${ROOTFSMNT}/etc/apt/preferences.d/raspi-config"
+		Package: raspi-config
+		Pin: release *
+		Pin-Priority: -1
+	EOF
 }

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -240,6 +240,10 @@ device_image_tweaks() {
 	curl -L --output "${ROOTFSMNT}/usr/bin/rpi-update" "https://raw.githubusercontent.com/${RpiUpdateRepo}/${RpiUpdateBranch}/rpi-update" &&
 		chmod +x "${ROOTFSMNT}/usr/bin/rpi-update"
 
+	log "Installing raspi-config blocker (Volumio OS does not support raspi-config)" "info"
+	cp "${SRC}/volumio/bin/raspi-config-disabled" "${ROOTFSMNT}/usr/bin/raspi-config"
+	chmod +x "${ROOTFSMNT}/usr/bin/raspi-config"
+
 	# ============================================================================
 	# RPI-UPDATE BUG FIX
 	# ============================================================================
@@ -792,4 +796,11 @@ device_image_tweaks_post() {
 		log "Updating plymouth systemd services" "info"
 		cp -dR "${SRC}"/volumio/framebuffer/systemd/* "${ROOTFSMNT}"/lib/systemd
 	fi
+
+	log "Blocking raspi-config package (Volumio OS does not support raspi-config)" "info"
+	cat <<-EOF >"${ROOTFSMNT}/etc/apt/preferences.d/raspi-config"
+		Package: raspi-config
+		Pin: release *
+		Pin-Priority: -1
+	EOF
 }

--- a/volumio/bin/raspi-config-disabled
+++ b/volumio/bin/raspi-config-disabled
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Volumio OS: raspi-config is not supported. It overwrites boot/config and can break the system.
+cat <<'EOF'
+--------------------------------------------------------------------------------
+raspi-config is not supported on Volumio OS.
+
+It is designed for Raspberry Pi OS and will overwrite Volumio's boot config,
+locale, and system settings. This can break or permanently damage your
+Volumio installation (e.g. boot failure, lost customisations).
+
+For locale, region, network, and system updates please use the Volumio web UI
+or the supported update process (Settings / System Update in the UI).
+--------------------------------------------------------------------------------
+EOF
+exit 1


### PR DESCRIPTION
On Pi and CM4 images, `raspi-config` is replaced by a wrapper that prints a short message and exits. The `raspi-config` package is blocked via apt preferences so it cannot be installed on the running system (including after a full upgrade).

**Why**  
`raspi-config` is for Raspberry Pi OS, not Volumio. Using it overwrites Volumio’s boot config (`config.txt` / `cmdline.txt`), locale, and system settings, and can break or “kill” the installation (e.g. boot failure, lost customisations). Users sometimes run it for locale/region; we need to prevent that and steer them to the Volumio UI and supported update path.

**How**  
- In `device_image_tweaks()`: install a wrapper script as `/usr/bin/raspi-config` (replacing or preempting the real binary).  
- In `device_image_tweaks_post()`: add `/etc/apt/preferences.d/raspi-config` with `Pin-Priority: -1` so the package is never installable.  
No multistrap or earlier build stages are changed; both changes happen in the device recipe phase.

**What is expected**  
- Running `raspi-config` (or `sudo raspi-config`) shows the warning and exits with non-zero.  
- The running OS cannot install `raspi-config` via apt or full upgrade; the block is in the built image.
