### PR TITLE
Allow IPv4 Link-Local assignment in DHCPCD

### DIFF
--- a/volumio/etc/dhcpcd.conf
+++ b/volumio/etc/dhcpcd.conf
@@ -10,5 +10,4 @@ option rapid_commit
 option ntp_servers
 require dhcp_server_identifier
 slaac private
-noipv4ll
 nohook lookup-hostname


### PR DESCRIPTION
Without Link-Local support we fail the Bonjour Conformance Test immediately (required for AirPlay). Generally speaking IPv4LL is triggered after a delay if DHCP fails.

I have tested that there is no regressions in connecting to a WiFi network. I don't know what other features need to be tested, many of which I don't have the capabilities to test probably.

If this is not a good enough solution, we shall find a better one. If by the time we need to perform AirPlay certification, a better solution has not been found, this will be the solution.

These changes are temporarily merged on [feat/acert](https://github.com/volumio/volumio-os/tree/feat/acert).