### PR TITLE
feat(kiosk): replace xorg metapackage with minimal X stack

### DIFF
--- a/scripts/components/install-kiosk-chromium.sh
+++ b/scripts/components/install-kiosk-chromium.sh
@@ -15,11 +15,21 @@ CMP_PACKAGES=(
   "chromium" "chromium-l10n" "chromium-common"
   # Keyboard config
   "keyboard-configuration"
-  # Display stuff
-  "openbox" "unclutter" "xorg" "xinit" "xinput"
-  # Fonts
+  # X server - targeted packages instead of the "xorg" metapackage
+  # WHY: "xorg" pulls in xserver-xorg-video-all (amdgpu, ati, radeon, nouveau,
+  # vesa, fbdev), xterm, and xorg-docs - none of which are needed.
+  # Pi/CM4/CM5 use vc4 KMS with the modesetting DDX built into xserver-xorg-core.
+  # See: https://github.com/volumio/volumio-os/issues/368
+  "xserver-xorg-core"           # X server with built-in modesetting DDX for vc4
+  "xserver-xorg-input-libinput" # Touch, mouse, and keyboard input
+  "x11-xserver-utils"           # xset, xrandr - used by kiosk start script
+  "xinit"                       # startx
+  # Window manager and display utilities
+  "openbox" "unclutter" "xinput"
+  # CJK and international font support for kiosk UI
+  # NOTE: These add ~30M installed. If international UI support is not needed
+  # for a specific OEM build, these can be omitted to save space.
   "fonts-arphic-ukai" "fonts-arphic-gbsn00lp" "fonts-unfonts-core"
-  # Fonts for Japanese and Thai languages
   "fonts-ipafont" "fonts-vlgothic" "fonts-thai-tlwg-ttf"
   # Chromium dependencies
   "libgtk-3-0" "libxnvctrl0" "xdg-utils"

--- a/scripts/components/install-kiosk-legacy-chromium.sh
+++ b/scripts/components/install-kiosk-legacy-chromium.sh
@@ -15,14 +15,21 @@ BrowerPckg="chromium"
 CMP_PACKAGES=(
   # Keyboard config
   "keyboard-configuration"
-  # Display stuff
-  "openbox" "unclutter" "xorg" "xinit"
+  # X server - targeted packages instead of the "xorg" metapackage
+  # WHY: "xorg" pulls in xserver-xorg-video-all (amdgpu, ati, radeon, nouveau,
+  # vesa, fbdev), xterm, and xorg-docs - none of which are needed.
+  # See: https://github.com/volumio/volumio-os/issues/368
+  "xserver-xorg-core"           # X server with built-in modesetting DDX
+  "xserver-xorg-input-libinput" # Touch, mouse, and keyboard input
+  "x11-xserver-utils"           # xset, xrandr - used by kiosk start script
+  "xinit"                       # startx
+  # Window manager and display utilities
+  "openbox" "unclutter"
   # Browser
   # TODO: Why not firefox? it seems to work OTB on most devices with less hassle?
   "${BrowerPckg}" "chromium-l10n"
-  # Fonts
+  # CJK and international font support for kiosk UI
   "fonts-arphic-ukai" "fonts-arphic-gbsn00lp" "fonts-unfonts-core"
-  # Fonts for Japanese and Thai languages
   "fonts-ipafont" "fonts-vlgothic" "fonts-thai-tlwg-ttf"
 )
 

--- a/scripts/components/install-kiosk-vivaldi.sh
+++ b/scripts/components/install-kiosk-vivaldi.sh
@@ -12,13 +12,23 @@ export DEBIAN_FRONTEND=noninteractive
 CMP_PACKAGES=(
   # Keyboard config
   "keyboard-configuration"
-  # Display stuff
-  "openbox" "xorg" "xinit" "libexif12" "unclutter" "libu2f-udev" "libvulkan1" "xinput"
-  # Browser dependencies 
+  # X server - targeted packages instead of the "xorg" metapackage
+  # WHY: "xorg" pulls in xserver-xorg-video-all (amdgpu, ati, radeon, nouveau,
+  # vesa, fbdev), xterm, and xorg-docs - none of which are needed.
+  # Pi/CM4/CM5 use vc4 KMS with the modesetting DDX built into xserver-xorg-core.
+  # See: https://github.com/volumio/volumio-os/issues/368
+  "xserver-xorg-core"           # X server with built-in modesetting DDX for vc4
+  "xserver-xorg-input-libinput" # Touch, mouse, and keyboard input
+  "x11-xserver-utils"           # xset, xrandr - used by kiosk start script
+  "xinit"                       # startx
+  # Window manager and display utilities
+  "openbox" "libexif12" "unclutter" "libu2f-udev" "libvulkan1" "xinput"
+  # Browser dependencies
   "fonts-liberation" "libatk-bridge2.0-0" "libatk1.0-0" "libatspi2.0-0" "libgtk-3-0" "libnspr4" "libnss3" "xdg-utils"
-  # Fonts
+  # CJK and international font support for kiosk UI
+  # NOTE: These add ~30M installed. If international UI support is not needed
+  # for a specific OEM build, these can be omitted to save space.
   "fonts-arphic-ukai" "fonts-arphic-gbsn00lp" "fonts-unfonts-core"
-  # Fonts for Japanese and Thai languages
   "fonts-ipafont" "fonts-vlgothic" "fonts-thai-tlwg-ttf"
 )
 


### PR DESCRIPTION
Install xserver-xorg-core, xserver-xorg-input-libinput, x11-xserver-utils, and xinit instead of the xorg metapackage (avoids xserver-xorg-video-all, xterm, xorg-docs). Applies to Chromium, legacy Chromium, and Vivaldi kiosk scripts. Document Pi vc4/modesetting rationale and issue #368; note optional CJK font cost for OEM builds.