### PR TITLE
build: bump kernel version to 6.12.75 for pi/cm4/cm5 recipes

### DIFF
--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -144,9 +144,10 @@ declare -A PI_KERNELS=(
 	[6.6.62]="9a9bda382acec723c901e5ae7c7f415d9afbf635|master|1816"
 	[6.12.47]="6d1da66a7b1358c9cd324286239f37203b7ce25c|master|1904"
 	[6.12.74]="7a35bddc777d8992bdfe42f8e3d043582df2f5f8|master|1948"
+	[6.12.75]="98655d3ccedba33aeadd0e550229f1496c5bf6f9|master|1949"
 )
 # Version we want
-KERNEL_VERSION="6.12.74"
+KERNEL_VERSION="6.12.75"
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)

--- a/recipes/devices/cm5.sh
+++ b/recipes/devices/cm5.sh
@@ -148,9 +148,10 @@ declare -A PI_KERNELS=(
 	[6.6.62]="9a9bda382acec723c901e5ae7c7f415d9afbf635|master|1816"
 	[6.12.47]="6d1da66a7b1358c9cd324286239f37203b7ce25c|master|1904"
 	[6.12.74]="7a35bddc777d8992bdfe42f8e3d043582df2f5f8|master|1948"
+	[6.12.75]="98655d3ccedba33aeadd0e550229f1496c5bf6f9|master|1949"
 )
 # Version we want
-KERNEL_VERSION="6.12.74"
+KERNEL_VERSION="6.12.75"
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -151,9 +151,10 @@ declare -A PI_KERNELS=(
 	[6.12.47]="6d1da66a7b1358c9cd324286239f37203b7ce25c|master|1904"
 	[6.12.50]="a22bb2f110bc8953523714ac58251f47ae4e2d2b|master|1909"
 	[6.12.74]="7a35bddc777d8992bdfe42f8e3d043582df2f5f8|master|1948"
+	[6.12.75]="98655d3ccedba33aeadd0e550229f1496c5bf6f9|master|1949"
 )
 # Version we want
-KERNEL_VERSION="6.12.74"
+KERNEL_VERSION="6.12.75"
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)


### PR DESCRIPTION
this is the latest stable kernel used on RaspiOS trixie