### PR TITLE
Revert "feat(wireless): Enable promiscuous mode on WiFi interface"

### DIFF
--- a/volumio/lib/systemd/system/wireless.service
+++ b/volumio/lib/systemd/system/wireless.service
@@ -6,7 +6,6 @@ Before=volumio.service
 Type=notify
 ExecStartPost=-/sbin/iw dev wlan0 set power_save off
 ExecStartPost=-/sbin/iwconfig wlan0 power off
-ExecStartPost=-/usr/bin/ip link set wlan0 promisc on
 ExecStart=/volumio/app/plugins/system_controller/network/wireless.js start
 KillMode=mixed
 


### PR DESCRIPTION
This reverts commit 06f19cee7cd7142e11fd1d944131d5454dc107b5. This change also requires https://github.com/volumio/volumio3-backend/pull/272 which is being held up.