### PR TITLE
fix(dhcpcd): Disallow systemd dhcpcd daemon from configuring eth0

### DIFF
--- a/volumio/etc/dhcpcd.conf
+++ b/volumio/etc/dhcpcd.conf
@@ -1,4 +1,4 @@
-allowinterfaces eth0 wlan0
+allowinterfaces wlan0
 hostname
 duid
 vendorclassid


### PR DESCRIPTION
Volumio is currently relying on two dhcpcd instances. However, if both are running on both interfaces things break.

Use the systemd dhcpcd for wlan0 only. The dhcpcd instance for eth0 is spawned by ifup according to `/etc/network/interfaces`.

These changes are temporarily merged on [feat/acert](https://github.com/volumio/volumio-os/tree/feat/acert).

Example:
```
volumio@motivo:~$ journalctl | grep dhcpcd
Apr 03 09:46:32 motivo sh[687]: dhcpcd-9.4.1 starting
Apr 03 09:46:32 motivo dhcpcd[687]: dhcpcd-9.4.1 starting
Apr 03 09:46:32 motivo dhcpcd[693]: DUID 00:01:00:01:31:5e:b6:69:d8:3a:dd:b1:f3:f9
Apr 03 09:46:32 motivo dhcpcd[693]: dhcp_vendor: No such process
Apr 03 09:46:32 motivo dhcpcd[693]: eth0: waiting for carrier
Apr 03 09:46:33 motivo systemd[1]: Starting dhcpcd.service - DHCP Client Daemon on all interfaces...
Apr 03 09:46:34 motivo dhcpcd[888]: dhcpcd-9.4.1 starting
Apr 03 09:46:34 motivo dhcpcd[888]: chrooting as dhcpcd to /usr/lib/dhcpcd
Apr 03 09:46:34 motivo dhcpcd[888]: dhcpcd-9.4.1 starting
Apr 03 09:46:34 motivo dhcpcd[888]: chrooting as dhcpcd to /usr/lib/dhcpcd
Apr 03 09:46:34 motivo dhcpcd[888]: sandbox: seccomp
Apr 03 09:46:34 motivo dhcpcd[888]: spawned manager process on PID 915
Apr 03 09:46:34 motivo dhcpcd[915]: spawned manager process on PID 915
Apr 03 09:46:34 motivo dhcpcd[916]: udev: starting
Apr 03 09:46:34 motivo dhcpcd[916]: dev: loaded udev
Apr 03 09:46:34 motivo dhcpcd[916]: spawned privileged proxy on PID 916
Apr 03 09:46:34 motivo dhcpcd[888]: udev: starting
Apr 03 09:46:34 motivo dhcpcd[888]: dev: loaded udev
Apr 03 09:46:34 motivo dhcpcd[888]: spawned privileged proxy on PID 916
Apr 03 09:46:34 motivo dhcpcd[916]: spawned network proxy on PID 917
Apr 03 09:46:34 motivo dhcpcd[888]: spawned network proxy on PID 917
Apr 03 09:46:34 motivo dhcpcd[888]: spawned controller proxy on PID 918
Apr 03 09:46:34 motivo dhcpcd[888]: DUID 00:01:00:01:31:5e:b6:69:d8:3a:dd:b1:f3:f9
Apr 03 09:46:34 motivo dhcpcd[888]: dhcp_vendor: No such process
Apr 03 09:46:34 motivo dhcpcd[916]: spawned controller proxy on PID 918
Apr 03 09:46:34 motivo dhcpcd[916]: DUID 00:01:00:01:31:5e:b6:69:d8:3a:dd:b1:f3:f9
Apr 03 09:46:34 motivo dhcpcd[916]: dhcp_vendor: No such process
Apr 03 09:46:34 motivo dhcpcd[916]: eth0: executing: /usr/lib/dhcpcd/dhcpcd-run-hooks PREINIT
Apr 03 09:46:34 motivo systemd[1]: Started dhcpcd.service - DHCP Client Daemon on all interfaces.
Apr 03 09:46:34 motivo dhcpcd[916]: eth0: executing: /usr/lib/dhcpcd/dhcpcd-run-hooks NOCARRIER
Apr 03 09:46:34 motivo dhcpcd[916]: wlan0: executing: /usr/lib/dhcpcd/dhcpcd-run-hooks PREINIT
Apr 03 09:46:34 motivo dhcpcd[916]: wlan0: executing: /usr/lib/dhcpcd/dhcpcd-run-hooks NOCARRIER
Apr 03 09:46:34 motivo dhcpcd[916]: eth0: waiting for carrier
Apr 03 09:46:34 motivo dhcpcd[916]: wlan0: waiting for carrier
Apr 03 09:46:36 motivo dhcpcd[693]: eth0: carrier acquired
Apr 03 09:46:36 motivo dhcpcd[916]: eth0: carrier acquired
Apr 03 09:46:36 motivo dhcpcd[916]: eth0: executing: /usr/lib/dhcpcd/dhcpcd-run-hooks CARRIER
Apr 03 09:46:36 motivo dhcpcd[693]: eth0: IAID dd:b1:f3:f8
Apr 03 09:46:36 motivo dhcpcd[693]: eth0: adding address fe80::6c50:6e66:f295:b64a
Apr 03 09:46:36 motivo dhcpcd[693]: ipv6_addaddr1: Permission denied
Apr 03 09:46:36 motivo dhcpcd[916]: eth0: IAID dd:b1:f3:f8
Apr 03 09:46:36 motivo dhcpcd[916]: eth0: adding address fe80::6c50:6e66:f295:b64a
Apr 03 09:46:36 motivo dhcpcd[916]: eth0: pltime infinity, vltime infinity
Apr 03 09:46:36 motivo dhcpcd[916]: ipv6_addaddr1: Permission denied
Apr 03 09:46:36 motivo dhcpcd[916]: eth0: delaying IPv6 router solicitation for 0.1 seconds
Apr 03 09:46:36 motivo dhcpcd[916]: eth0: delaying IPv4 for 0.7 seconds
Apr 03 09:46:36 motivo dhcpcd[916]: eth0: soliciting an IPv6 router
Apr 03 09:46:36 motivo dhcpcd[916]: eth0: delaying Router Solicitation for LL address
Apr 03 09:46:37 motivo dhcpcd[693]: eth0: soliciting an IPv6 router
Apr 03 09:46:37 motivo dhcpcd[916]: eth0: reading lease: /var/lib/dhcpcd/eth0.lease
Apr 03 09:46:37 motivo dhcpcd[916]: eth0: soliciting a DHCP lease
Apr 03 09:46:37 motivo dhcpcd[916]: eth0: sending DISCOVER (xid 0x41e571f8), next in 4.4 seconds
Apr 03 09:46:37 motivo dhcpcd[916]: eth0: spawned BPF BOOTP on PID 1157
Apr 03 09:46:38 motivo dhcpcd[693]: eth0: soliciting a DHCP lease
Apr 03 09:46:38 motivo sudo[1199]:     root : PWD=/ ; USER=root ; COMMAND=/sbin/dhcpcd -k wlan0
Apr 03 09:46:38 motivo dhcpcd[1200]: dhcpcd not running
Apr 03 09:46:38 motivo wireless.js[801]: dhcpcd not running
Apr 03 09:46:41 motivo dhcpcd[916]: eth0: sending DISCOVER (xid 0x41e571f8), next in 7.2 seconds
Apr 03 09:46:42 motivo dhcpcd[916]: eth0: probing for an IPv4LL address
Apr 03 09:46:42 motivo dhcpcd[916]: eth0: spawned BPF ARP on PID 1318
Apr 03 09:46:42 motivo dhcpcd[916]: eth0: probing for 169.254.11.201
Apr 03 09:46:42 motivo dhcpcd[916]: eth0: ARP probing 169.254.11.201 (1 of 3), next in 1.1 seconds
Apr 03 09:46:42 motivo dhcpcd[916]: eth0: d0:11:e5:6c:ec:e3(d0:11:e5:6c:ec:e3) claims 169.254.11.201
Apr 03 09:46:43 motivo dhcpcd[693]: eth0: probing for an IPv4LL address
Apr 03 09:46:43 motivo dhcpcd[693]: eth0: d0:11:e5:6c:ec:e3(d0:11:e5:6c:ec:e3) claims 169.254.11.201
Apr 03 09:46:43 motivo dhcpcd[916]: eth0: probing for an IPv4LL address
Apr 03 09:46:43 motivo dhcpcd[916]: eth0: spawned BPF ARP on PID 1352
Apr 03 09:46:43 motivo dhcpcd[916]: eth0: probing for 169.254.6.187
Apr 03 09:46:43 motivo dhcpcd[916]: eth0: ARP probing 169.254.6.187 (1 of 3), next in 1.4 seconds
Apr 03 09:46:43 motivo dhcpcd[916]: eth0: d0:11:e5:6c:ec:e3(d0:11:e5:6c:ec:e3) claims 169.254.6.187
Apr 03 09:46:44 motivo dhcpcd[693]: eth0: probing for an IPv4LL address
Apr 03 09:46:44 motivo dhcpcd[693]: eth0: d0:11:e5:6c:ec:e3(d0:11:e5:6c:ec:e3) claims 169.254.6.187
Apr 03 09:46:44 motivo dhcpcd[916]: eth0: probing for an IPv4LL address
Apr 03 09:46:44 motivo dhcpcd[916]: eth0: spawned BPF ARP on PID 1354
Apr 03 09:46:44 motivo dhcpcd[916]: eth0: probing for 169.254.162.46
Apr 03 09:46:44 motivo dhcpcd[916]: eth0: ARP probing 169.254.162.46 (1 of 3), next in 1.1 seconds
Apr 03 09:46:44 motivo dhcpcd[916]: eth0: d0:11:e5:6c:ec:e3(d0:11:e5:6c:ec:e3) claims 169.254.162.46
Apr 03 09:46:45 motivo dhcpcd[693]: eth0: probing for an IPv4LL address
Apr 03 09:46:45 motivo dhcpcd[693]: eth0: d0:11:e5:6c:ec:e3(d0:11:e5:6c:ec:e3) claims 169.254.162.46
Apr 03 09:46:45 motivo dhcpcd[916]: eth0: probing for an IPv4LL address
Apr 03 09:46:45 motivo dhcpcd[916]: eth0: spawned BPF ARP on PID 1361
Apr 03 09:46:45 motivo dhcpcd[916]: eth0: probing for 169.254.92.97
Apr 03 09:46:45 motivo dhcpcd[916]: eth0: ARP probing 169.254.92.97 (1 of 3), next in 2.0 seconds
Apr 03 09:46:45 motivo dhcpcd[916]: eth0: d0:11:e5:6c:ec:e3(d0:11:e5:6c:ec:e3) claims 169.254.92.97
Apr 03 09:46:46 motivo dhcpcd[693]: eth0: probing for an IPv4LL address
Apr 03 09:46:46 motivo dhcpcd[916]: eth0: probing for an IPv4LL address
Apr 03 09:46:46 motivo dhcpcd[916]: eth0: probing for 169.254.104.48
Apr 03 09:46:46 motivo dhcpcd[916]: eth0: spawned BPF ARP on PID 1382
Apr 03 09:46:46 motivo dhcpcd[916]: eth0: ARP probing 169.254.104.48 (1 of 3), next in 1.2 seconds
Apr 03 09:46:47 motivo dhcpcd[916]: eth0: ARP probing 169.254.104.48 (2 of 3), next in 1.2 seconds
Apr 03 09:46:49 motivo dhcpcd[916]: eth0: ARP probing 169.254.104.48 (3 of 3), next in 2.0 seconds
Apr 03 09:46:49 motivo dhcpcd[916]: eth0: sending DISCOVER (xid 0x41e571f8), next in 17.0 seconds
Apr 03 09:46:51 motivo dhcpcd[916]: eth0: using IPv4LL address 169.254.104.48
Apr 03 09:46:51 motivo dhcpcd[916]: eth0: adding IP address 169.254.104.48/16 broadcast 169.254.255.255
Apr 03 09:46:51 motivo dhcpcd[916]: eth0: adding route to 169.254.0.0/16
Apr 03 09:46:51 motivo dhcpcd[916]: eth0: adding default route
Apr 03 09:46:51 motivo dhcpcd[916]: eth0: ARP announcing 169.254.104.48 (1 of 2), next in 2.0 seconds
Apr 03 09:46:51 motivo dhcpcd[916]: eth0: executing: /usr/lib/dhcpcd/dhcpcd-run-hooks IPV4LL
Apr 03 09:46:51 motivo dhcpcd[693]: eth0: using IPv4LL address 169.254.92.97
Apr 03 09:46:51 motivo dhcpcd[693]: eth0: adding route to 169.254.0.0/16
Apr 03 09:46:51 motivo dhcpcd[693]: eth0: adding default route
Apr 03 09:46:53 motivo dhcpcd[916]: eth0: ARP announcing 169.254.104.48 (2 of 2)
Apr 03 09:47:06 motivo dhcpcd[916]: eth0: sending DISCOVER (xid 0x41e571f8), next in 31.5 seconds
Apr 03 09:47:37 motivo dhcpcd[916]: eth0: sending DISCOVER (xid 0x41e571f8), next in 64.5 seconds
Apr 03 09:48:42 motivo dhcpcd[916]: eth0: sending DISCOVER (xid 0x41e571f8), next in 64.4 seconds
```

Instances of dhcpcd at 693 and 916 are both working on eth0 to get an IPv4LL address.