### PR TITLE
fix(initramfs-pi): respect UUID/LABEL imgpart when eMMC is present

### DIFF
--- a/scripts/initramfs/custom/pi/custom-functions
+++ b/scripts/initramfs/custom/pi/custom-functions
@@ -5,6 +5,19 @@ custom_init_partition_params() {
 # After upgrade from block device UUID will not be active yet. Use genpnames:
 log_begin_msg "Checking if device is booted from SD card" && log_end_msg
 
+# When imgpart uses UUID=/LABEL= (normal shipped cmdline), never force mmcblk0 +
+# DO_GEN just because /dev/mmcblk* exists. Otherwise USB boot breaks on boards
+# that always expose eMMC as mmcblk0 while the flashed USB stick is the boot volume.
+# Post-upgrade path keeps genpnames on cmdline and still runs the loop below.
+if ! grep -qw genpnames /proc/cmdline; then
+  case "${IMAGE_PARTITION}" in
+    UUID=*|LABEL=*|uuid=*|label=*)
+      BOOT_CONFIG="cmdline.txt"
+      return
+      ;;
+  esac
+fi
+
 for devlink in /dev/mmcblk[0-9]; do
   if [ "${devlink}" == "/dev/mmcblk[0-9]" ]; then
   # no MMC block devices present


### PR DESCRIPTION
Skip mmcblk0 + DO_GEN inference in custom_init_partition_params() when imgpart uses UUID= or LABEL= and genpnames is not on the kernel cmdline.

Prevents partition discovery from targeting onboard eMMC while the system is USB-booted from an image whose cmdline identifies volumes by UUID.

Refs: USB boot failure with "Waiting for USB devices" / stuck early init on CM-class boards where /dev/mmcblk0 always exists.