### PR TITLE
fix: triggerhappy not restarted after USB HID device connection/disconnection

### DIFF
--- a/volumio/etc/udev/rules.d/99-restart-thd-on-hid.rules
+++ b/volumio/etc/udev/rules.d/99-restart-thd-on-hid.rules
@@ -1,2 +1,2 @@
-# This udev rule restarts the triggerhappy service when a Bluetooth HID device is added or removed.
+# This udev rule restarts the triggerhappy service when a Bluetooth or USB HID device is added or removed.
 ACTION=="add|remove", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_BUS}=="bluetooth|usb", RUN+="/bin/systemctl restart triggerhappy"

--- a/volumio/etc/udev/rules.d/99-restart-thd-on-hid.rules
+++ b/volumio/etc/udev/rules.d/99-restart-thd-on-hid.rules
@@ -1,3 +1,2 @@
 # This udev rule restarts the triggerhappy service when a Bluetooth HID device is added or removed.
-ACTION=="add", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_BUS}=="bluetooth", RUN+="/bin/systemctl restart triggerhappy"
-ACTION=="remove", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_BUS}=="bluetooth", RUN+="/bin/systemctl restart triggerhappy"
+ACTION=="add|remove", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_BUS}=="bluetooth|usb", RUN+="/bin/systemctl restart triggerhappy"


### PR DESCRIPTION
Changed udev rule responsible of restarting triggerhappy in 2 ways:
1. Simplified it to reduce code duplication
2. add support for USB HID devices.