### PR TITLE
fix(pi): adjust memory usage of vc4-kms-v3d for Pi 3A+ to prevent boot failure

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -711,6 +711,9 @@ device_chroot_tweaks_pre() {
 		# Firmware auto-remaps overlay to board-specific variant
 		[pi2]
 		dtoverlay=vc4-kms-v3d
+		# Before applying to [pi3], disable for Pi 3A+ (0x9020e0) specifically
+		[0x9020e0]
+		dtoverlay=
 		[pi3]
 		dtoverlay=vc4-kms-v3d
 		[pi4]

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -711,9 +711,10 @@ device_chroot_tweaks_pre() {
 		# Firmware auto-remaps overlay to board-specific variant
 		[pi2]
 		dtoverlay=vc4-kms-v3d
-		# Before applying to [pi3], disable for Pi 3A+ (0x9020e0) specifically
+		# Pi 3A+ (0x9020e0): Before applying to [pi3], apply with lower 128MB contiguous memory setting
+		# Pi 3A+ has only 512MB RAM and suffers boot issues otherwise
 		[0x9020e0]
-		dtoverlay=
+		dtoverlay=vc4-kms-v3d,cma-128
 		[pi3]
 		dtoverlay=vc4-kms-v3d
 		[pi4]


### PR DESCRIPTION
Addresses https://github.com/volumio/volumio-os/issues/394

When trying to install the latest Volumio OS image on a Raspberry Pi 3A+, I noticed that images after 4.073-2025-12-05 wouldn't boot. After a clean flash, the activity light would blink briefly and then nothing. There was no display output.

Tested on:
- Raspberry Pi 3A+
- Build Volumio-4.073-2025-12-05-pi.img - Worked
- Build Volumio-4.096-2026-02-05-pi.img - Crash
- Build Volumio-4.103-2026-03-06-pi.img - Crash
- Build Volumio-4.2.119-2026-03-24-pi - Crash

With the help of AI and commit bisecting, I traced the issue down to [Commit 2a9231b](https://github.com/volumio/volumio-os/commit/2a9231b23d0f742314721874b89f4a013f15a93f) which added the vc4-kms-v3d dtoverlay for all pi models. Unfortunately the 3A+ only has 512MB of ram and this setting allocates too much, causing the boot crash. I noticed the fix added for pi02 in [Commit f2c0bb4](https://github.com/volumio/volumio-os/commit/f2c0bb4bb3ea57a378f9c694be21a37edc6d331a), but after some research, found that the pi 3A+ can use the overlay with a lower memory setting. I added a section specifying the lower memory setting for the 3A+, using the model's hardware code (0x9020e0), and ensuring it came before the [pi3] entry.

I verified the fix by running community builds from master on my fork both before and after the fix.
- Before the fix: Crash
- After the fix: Works!

I would bet this problem affects the 2A+ and 2B+ as well, but I don't have devices to test with.