### PR TITLE
fix: correct read timeout parameter in pause() function

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -99,7 +99,7 @@ check_size() {
 
 pause() {
 	local timeout=${1:=30}	
-	read -rp "Waiting ${timeout} secs or press any key to continue..."; echo
+	read -t "${timeout}" -rp "Waiting ${timeout} secs or press any key to continue..."; echo
 	log "Continuing.."
 }
 


### PR DESCRIPTION
Fixed variable reference in read -t command by using \"\$timeout\"
This ensures proper timeout handling..

Tested on Debian GNU/Linux 12 (bookworm)  with bash 5.1.12"