### PR TITLE
fix: remove stray quote in dpkg config

### DIFF
--- a/scripts/rootfs/volumioconfig.sh
+++ b/scripts/rootfs/volumioconfig.sh
@@ -45,7 +45,7 @@ path-exclude /usr/share/groff/*
 path-exclude /usr/share/info/*
 # lintian stuff is small, but really unnecessary
 path-exclude /usr/share/lintian/*
-path-exclude /usr/share/linda/*"
+path-exclude /usr/share/linda/*
 EOF
 
 export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true


### PR DESCRIPTION
Removed the stray double quote at the end of 01_nodoc.