### PR TITLE
fix(cm0): enable i2c-1 interface

### DIFF
--- a/recipes/devices/cm0.sh
+++ b/recipes/devices/cm0.sh
@@ -640,6 +640,8 @@ device_chroot_tweaks_pre() {
 		dtparam=audio=off
 		disable_splash=1
 		enable_tvout=0
+		dtparam=i2c=on
+		dtparam=i2c_baudrate=400000
 		include volumioconfig.txt
 	EOF
 


### PR DESCRIPTION
enable I2C-1 interface with additional declarations in config.txt

this change has been verified with manual changes on an existing cm0 image