### PR TITLE
fix(kiosk): wait for Volumio REST API instead of raw port bind

### DIFF
--- a/scripts/components/install-kiosk-chromium.sh
+++ b/scripts/components/install-kiosk-chromium.sh
@@ -133,8 +133,8 @@ if [ ! -f /data/volumiokiosk/firststartdone ]; then
   touch /data/volumiokiosk/firststartdone
 fi
 
-# Wait for Volumio webUI to be available
-while true; do timeout 5 bash -c "</dev/tcp/127.0.0.1/3000" >/dev/null 2>&1 && break; done
+# Wait for the Volumio REST API to actually serve (not just the port to be bound)
+while ! curl -fsS -m 5 -o /dev/null http://127.0.0.1:3000/api/v1/ping; do sleep 1; done
 echo "Waited \$((\$(date +%s) - start)) sec for Volumio UI"
 
 # Start Openbox


### PR DESCRIPTION
## Problem
The chromium kiosk waited for the UI with a raw TCP connect:
```sh
while true; do timeout 5 bash -c "</dev/tcp/127.0.0.1/3000" >/dev/null 2>&1 && break; done
```
That connect succeeds the instant node **binds** `:3000` — well before the backend REST API / concept-ui is ready to serve. On slow first boots (fresh `/data`, plugin init, OEM activation gate) chromium launched against a not-ready backend and showed a stuck/blank UI. Perceived as "kiosk browser not up on first boot" on Pi5 oem-kiosk (PecanPi+).

## Fix
Poll the Volumio REST endpoint instead — `/api/v1/ping` returns `200 pong` only once the API is actually serving:
```sh
while ! curl -fsS -m 5 -o /dev/null http://127.0.0.1:3000/api/v1/ping; do sleep 1; done
```

## Testing
- `bash -n` clean; `/api/v1/ping` → `200 pong` verified live.
- Deployed to a Pi5 oem-kiosk unit, rebooted → kiosk comes up against a ready UI, no `net::`/`ERR_` in `/var/log/volumiokiosk.log`. Confirmed correct on-screen.

## Scope
Affects all chromium-kiosk builds (`install-kiosk-chromium.sh`), not oem-kiosk only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)