### PR TITLE
fix: bypass raspbian redirector and bound apt stalls in multistrap

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -177,7 +177,7 @@ function setup_multistrap() {
 
   mkdir -p "${DirEtcparts}"
   mkdir -p "${DirEtctrustedparts}"
-  echo -e 'Dpkg::Progress-Fancy "1";\nAPT::Color "1";' > \
+  echo -e 'Dpkg::Progress-Fancy "1";\nAPT::Color "1";\nAcquire::http::Timeout "30";\nAcquire::Retries "3";\nAcquire::http::Pipeline-Depth "0";' > \
     "${DirEtcparts}"/01progress
 
   if [[ -n "${APT_CACHE}" ]] && ! curl -sSf "${APT_CACHE}" >/dev/null; then
@@ -208,7 +208,7 @@ function patch_multistrap_conf() {
     log "Patching multistrap config to point to Raspbian sources" "info"
     export RASPBIANCONF=recipes/base/arm-raspbian.conf
     debian_source=http://deb.debian.org/debian
-    rapsbian_source=http://mirrordirector.raspbian.org/raspbian
+    rapsbian_source=http://archive.raspbian.org/raspbian
     upmpdcli_source=http://www.lesbonscomptes.com/upmpdcli/downloads
 
     cat <<-EOF >"${SRC}/${RASPBIANCONF}"


### PR DESCRIPTION
## Summary

Since 2026-07-20 every arm build hangs forever in multistrap. Root cause: the raspbian redirector (`mirrordirector.raspbian.org`, also behind the `raspbian.raspberrypi.com` CNAME) 302-redirects `pool/` downloads to random community mirrors, some of which are currently broken. apt 2.6.1 collects `Ign:` failures, retries, and deadlocks its acquire queue with all http workers idle in `select()`. With no apt timeout configured, and multistrap's stdout redirected to `multistrap.log`, the build sits silently on the console forever.

## Changes

- Point the generated `arm-raspbian.conf` at `archive.raspbian.org` — the master archive: direct file serving, keep-alive, no redirector lottery.
- Write `Acquire::http::Timeout "30"`, `Acquire::Retries "3"` and `Acquire::http::Pipeline-Depth "0"` into the rootfs apt config that multistrap picks up, so any stalled mirror fails loudly within seconds instead of hanging the build forever. Applies to all suites/architectures.