### PR TITLE
fix: bypass raspbian redirector in the rootfs apt source too

### DIFF
--- a/recipes/configurations/config.sh
+++ b/recipes/configurations/config.sh
@@ -12,7 +12,7 @@ declare -A SecureApt=(
 # Repo locations that are utilised to create source.list in the rootfs
 declare -A APTSOURCE=(
   [Debian]="http://deb.debian.org/debian"
-  [Raspbian]="http://raspbian.raspberrypi.com/raspbian/"
+  [Raspbian]="http://archive.raspbian.org/raspbian/"
 )
 
 ## Path to the volumio repo


### PR DESCRIPTION
## Summary

Follow-up to #415. The chroot install phases (e.g. the kiosk package install) use `APTSOURCE[Raspbian]` for the rootfs `/etc/apt/sources.list`, which still pointed at `raspbian.raspberrypi.com` (the redirector) and hit the same silent apt deadlock — the Acquire timeout options don't help because the deadlocked workers consider themselves idle.

## Changes

- Point `APTSOURCE[Raspbian]` at `archive.raspbian.org` (master archive, direct file serving, keep-alive). Note: this is also the apt source shipped in the final image.