### PR TITLE
fix(kiosk): remove x86 GPU chromium flags — fatal with Chromium 149+

### DIFF
--- a/scripts/components/install-kiosk-chromium.sh
+++ b/scripts/components/install-kiosk-chromium.sh
@@ -74,19 +74,6 @@ CHROMIUM_FLAGS=(
   "--load-extension='/data/volumiokioskextensions/VirtualKeyboard/'"
 )
 
-if [[ ${BUILD:0:3} != 'arm' ]]; then
-  log "Adding additional chromium flags for x86"
-  # Again, these flags probably need to be revisited and checked!
-  CHROMIUM_FLAGS+=(
-    #GPU
-    "--ignore-gpu-blacklist"
-    "--use-gl=desktop"
-    "--disable-gpu-compositing"
-    "--force-gpu-rasterization"
-    "--enable-zero-copy"
-  )
-fi
-
 log "Adding ${#CHROMIUM_FLAGS[@]} Chromium flags"
 
 #TODO: Instead of all this careful escaping, make a simple template and add in CHROMIUM_FLAGS?


### PR DESCRIPTION
## Problem

The "x86-only" GPU flag block in `install-kiosk-chromium.sh` is guarded by `[[ ${BUILD:0:3} != 'arm' ]]`, but `BUILD` is sourced (not exported) in `chrootconfig.sh` and `install-kiosk.sh` runs as a child process — so the guard sees an empty `BUILD` and the flags land on **every** kiosk build, ARM included.

Chromium 149+ rejects `--use-gl=desktop` (`Requested GL implementation (gl=none,angle=none) not found`): the GPU process crash-loops 3 times at startup, then Chromium falls back to SwiftShader software rendering on every boot.