### PR TITLE
fix(kiosk): use native EGL instead of ANGLE for Vivaldi kiosk

### DIFF
--- a/scripts/components/install-kiosk-vivaldi.sh
+++ b/scripts/components/install-kiosk-vivaldi.sh
@@ -96,7 +96,7 @@ while [[ $(curl -Is http://localhost:3000 | head -n 1 | cut -d " " -f 2) != 200 
 openbox-session & 
 sleep 4 
 
-/usr/bin/vivaldi --kiosk --no-sandbox --disable-background-networking --disable-remote-extensions --disable-pinch --ignore-gpu-blocklist --use-gl=angle --use-angle=gl --enable-gpu-rasterization --enable-zero-copy --disable-smooth-scrolling --enable-scroll-prediction --max-tiles-for-interest-area=256 --num-raster-threads=4 --user-agent="volumiokiosk-touch" --touch-events --user-data-dir='/data/volumiokiosk' --force-device-scale-factor=$SCALE_FACTOR --load-extension='/data/volumiokioskextensions/VirtualKeyboard/' --no-first-run --app=http://localhost:3000
+/usr/bin/vivaldi --kiosk --no-sandbox --disable-background-networking --disable-remote-extensions --disable-pinch --ignore-gpu-blocklist --use-gl=egl --enable-gpu-rasterization --enable-zero-copy --disable-smooth-scrolling --enable-scroll-prediction --max-tiles-for-interest-area=256 --num-raster-threads=4 --user-agent="volumiokiosk-touch" --touch-events --user-data-dir='/data/volumiokiosk' --force-device-scale-factor=$SCALE_FACTOR --load-extension='/data/volumiokioskextensions/VirtualKeyboard/' --no-first-run --app=http://localhost:3000
 ' > /opt/volumiokiosk.sh
 
 /bin/chmod +x /opt/volumiokiosk.sh


### PR DESCRIPTION
## Problem

The Vivaldi kiosk is launched with `--use-gl=angle --use-angle=gl`. ANGLE-over-GL requests **async page flips** via X Present. On **fkms** devices (`vc4-fkms-v3d` — e.g. Pi3 driving a DSI panel) the driver rejects every async flip:

```
[drm:vc4_fkms_page_flip [vc4]] *ERROR* Async flips aren't allowed
```

Chromium then busy-loops repainting. Measured on a Pi3 DSI unit: Vivaldi steady-state CPU **~262%** (one GPU process pegged at 500%), load **11+** — a static kiosk screen was "slow as hell".

fkms cannot be swapped for full KMS on Pi3: full KMS wedges the DSI panel (documented in the `[pi3]` section of `volumioconfig.txt`). So the fix has to be at the browser layer.

## Fix

Switch `--use-gl=angle --use-angle=gl` → `--use-gl=egl` (native v3d/mesa GLES). Proper vsync → **synchronous** flips the fkms driver accepts → no busy-loop.

## Verified live (Pi3 + DSI)

| Metric | ANGLE (before) | EGL (after) |
|---|---|---|
| Vivaldi steady CPU | 262% | **54%** |
| Top GPU process | 500% | 33% |
| Async-flip kernel spam | continuous | **0 new** |
| Load avg | 11+ | 2.4 |
| DSI panel | connected | **still connected** |

## Universal

ANGLE-over-GL is pure translation overhead on every Pi/SBC. Native EGL is the correct path on full-KMS boards (Pi4/Pi5/CM4/CM5) and non-Pi platforms (Rockchip/MP1, x86) too. One shared kiosk launcher, all devices — no device is worse off than the ANGLE translation layer.

## Not touched

`install-kiosk-chromium.sh` / `install-kiosk-legacy-chromium.sh` use `--use-gl=desktop` (different browser, different flag). Same class of concern but untested here — left for a separate, tested change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)